### PR TITLE
bring lighthouse-lambda up to node 12 and lighthouse 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@ Run [Google Chrome Lighthouse](https://github.com/GoogleChrome/lighthouse) on [A
 
 ## Versions
 
-Since version 2.x, `lighthouse-lambda` has the same major version of [lighthouse](https://www.npmjs.com/package/lighthouse). For example, `lighthouse-lambda` 3.x will use `lighthouse` 3.x.
+Since version 2.x, `lighthouse-lambda` has the same major version of [lighthouse](https://www.npmjs.com/package/lighthouse). For example, `lighthouse-lambda` 5.x will use `lighthouse` 5.x.
 
-This README is for version 3.x. To see older versions, visit:
+This README is for version 5.x. To see older versions, visit:
 
 - 2.x: https://github.com/joytocode/lighthouse-lambda/tree/archived-v2
+- TODO: add link to version 3.x
 
 ## Installation
 
@@ -26,9 +27,7 @@ const createLighthouse = require('lighthouse-lambda')
 exports.handler = function (event, context, callback) {
   Promise.resolve()
     .then(() => createLighthouse('https://example.com', { logLevel: 'info' }))
-    .then(({ chrome, start }) => {
-      return start()
-        .then((results) => {
+    .then(({ chrome, results }) => {
           // Do something with `results`
           return chrome.kill().then(() => callback(null))
         })
@@ -36,7 +35,6 @@ exports.handler = function (event, context, callback) {
           // Handle errors when running Lighthouse
           return chrome.kill().then(() => callback(error))
         })
-    })
     // Handle other errors
     .catch(callback)
 }
@@ -47,7 +45,7 @@ exports.handler = function (event, context, callback) {
 You can use [docker-lambda](https://github.com/lambci/docker-lambda) to test your Lambda function locally.
 
 ```bash
-$ docker run --rm -v "$PWD":/var/task lambci/lambda:nodejs8.10 index.handler
+$ docker run --rm -v "$PWD":/var/task lambci/lambda:nodejs12.x index.handler
 ```
 
 ## Deployment
@@ -55,9 +53,9 @@ $ docker run --rm -v "$PWD":/var/task lambci/lambda:nodejs8.10 index.handler
 You can use [docker-lambda](https://github.com/lambci/docker-lambda) to install dependencies and pack your Lambda function.
 
 ```bash
-$ docker run --rm -v "$PWD":/var/task lambci/lambda:build-nodejs8.10 bash -c "rm -rf node_modules && npm install"
+$ docker run --rm -v "$PWD":/var/task lambci/lambda:build-nodejs12.x bash -c "rm -rf node_modules && npm install"
 
-$ docker run --rm -v "$PWD":/var/task lambci/lambda:build-nodejs8.10 bash -c "rm -f *.zip && zip lambda.zip -r node_modules index.js package.json"
+$ docker run --rm -v "$PWD":/var/task lambci/lambda:build-nodejs12.x bash -c "rm -f *.zip && zip lambda.zip -r node_modules index.js package.json"
 ```
 
 - The file will be big (at least 75MB), so you need to upload it to S3 then deploy to Lambda from S3.
@@ -73,11 +71,11 @@ Returns a `Promise` of an Object with the following fields:
 
 - `chrome`: an instance of [`chromeLauncher.launch()`](https://github.com/GoogleChrome/chrome-launcher#launchopts), remember to call `chrome.kill()` in the end.
 - `log`: an instance of [lighthouse-logger](https://github.com/GoogleChrome/lighthouse/tree/master/lighthouse-logger) (only if you set `options.logLevel`).
-- `start()`: a function to start the scan which returns a `Promise` of Lighthouse results.
 
 ## Credits
 
-`lighthouse-lambda` uses the Headless Chrome binary (stable version) from [@serverless-chrome/lambda](https://www.npmjs.com/package/@serverless-chrome/lambda).
+- Version 5.6 `lighthouse-lambda` uses Headless Chrome from [chrome-aws-lambda](https://www.npmjs.com/package/chrome-aws-lambda).
+- Version 3 `lighthouse-lambda` uses the Headless Chrome binary (stable version) from [@serverless-chrome/lambda](https://www.npmjs.com/package/@serverless-chrome/lambda).
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 const chromium = require('chrome-aws-lambda')
-const lighthouse = require('lighthouse')
 const chromeLauncher = require('chrome-launcher');
+const lighthouse = require('lighthouse')
 
 const defaultFlags = [
   '--headless',
@@ -8,8 +8,8 @@ const defaultFlags = [
   '--disable-gpu',
   '--no-zygote',
   '--no-sandbox',
-  '--hide-scrollbars',
-  '--single-process'
+  '--single-process',
+  '--hide-scrollbars'
 ]
 
 chromePath = undefined;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 const chromium = require('chrome-aws-lambda')
-const chromeLauncher = require('chrome-launcher');
+const chromeLauncher = require('chrome-launcher')
 const lighthouse = require('lighthouse')
 
 const defaultFlags = [

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
 const chromium = require('chrome-aws-lambda')
-const chromeLauncher = require('chrome-launcher')
 const lighthouse = require('lighthouse')
 
 const defaultFlags = [
@@ -18,9 +17,14 @@ module.exports = async function createLighthouse(url, options = {}, config) {
     log.setLevel(options.logLevel)
   }
   const chromeFlags = options.chromeFlags || defaultFlags
-  return chromeLauncher.launch({ chromeFlags, chromePath: await chromium.executablePath })
+  return chromium.puppeteer.launch({
+    args: chromeFlags,
+    executablePath: await chromium.executablePath,
+    headless: chromium.headless,
+    defaultViewport: chromium.defaultViewport,
+  })
     .then((chrome) => {
-      options.port = chrome.port
+      options.port = new URL(chrome.wsEndpoint()).port
       return {
         chrome,
         log,

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,6 @@ const defaultFlags = [
 chromePath = undefined;
 
 if (['AWS_Lambda_nodejs10.x', 'AWS_Lambda_nodejs12.x'].includes(process.env.AWS_EXECUTION_ENV) === true) {
-  console.log("here")
   if (process.env.FONTCONFIG_PATH === undefined) {
     process.env.FONTCONFIG_PATH = '/tmp/aws';
 
@@ -35,15 +34,11 @@ module.exports = async function createLighthouse(url, options = {}, config) {
     log.setLevel(options.logLevel)
   }
   const chromeFlags = options.chromeFlags || defaultFlags
-  console.log("path =" + chromePath)
   if (!chromePath) { chromePath = await chromium.executablePath }
-  console.log("afterpath =" + chromePath)
   let chrome = await chromeLauncher.launch({
     chromeFlags, chromePath
   });
-  console.log("before endpoint")
   options.port = chrome.port
-  console.log("port: " + options.port)
   const results = await lighthouse(url, options, config)
   return {
     chrome,

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-const chromePath = require.resolve('@serverless-chrome/lambda/dist/headless-chromium')
+const chromium = require('chrome-aws-lambda')
 const chromeLauncher = require('chrome-launcher')
 const lighthouse = require('lighthouse')
 
@@ -8,24 +8,23 @@ const defaultFlags = [
   '--disable-gpu',
   '--no-zygote',
   '--no-sandbox',
-  '--single-process',
   '--hide-scrollbars'
 ]
 
-module.exports = function createLighthouse (url, options = {}, config) {
+module.exports = async function createLighthouse(url, options = {}, config) {
   options.output = options.output || 'html'
   const log = options.logLevel ? require('lighthouse-logger') : null
   if (log) {
     log.setLevel(options.logLevel)
   }
   const chromeFlags = options.chromeFlags || defaultFlags
-  return chromeLauncher.launch({ chromeFlags, chromePath })
+  return chromeLauncher.launch({ chromeFlags, chromePath: await chromium.executablePath })
     .then((chrome) => {
       options.port = chrome.port
       return {
         chrome,
         log,
-        start () {
+        start() {
           return lighthouse(url, options, config)
         }
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ const defaultFlags = [
   '--disable-gpu',
   '--no-zygote',
   '--no-sandbox',
-  '--hide-scrollbars'
+  '--hide-scrollbars',
+  '--single-process'
 ]
 
 chromePath = undefined;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 const chromium = require('chrome-aws-lambda')
 const lighthouse = require('lighthouse')
+const chromeLauncher = require('chrome-launcher');
 
 const defaultFlags = [
   '--headless',
@@ -10,6 +11,22 @@ const defaultFlags = [
   '--hide-scrollbars'
 ]
 
+chromePath = undefined;
+
+if (['AWS_Lambda_nodejs10.x', 'AWS_Lambda_nodejs12.x'].includes(process.env.AWS_EXECUTION_ENV) === true) {
+  console.log("here")
+  if (process.env.FONTCONFIG_PATH === undefined) {
+    process.env.FONTCONFIG_PATH = '/tmp/aws';
+
+  }
+
+  if (process.env.LD_LIBRARY_PATH === undefined) {
+    process.env.LD_LIBRARY_PATH = '/tmp/aws/lib';
+  } else if (process.env.LD_LIBRARY_PATH.startsWith('/tmp/aws/lib') !== true) {
+    process.env.LD_LIBRARY_PATH = [...new Set(['/tmp/aws/lib', ...process.env.LD_LIBRARY_PATH.split(':')])].join(':');
+  }
+}
+
 module.exports = async function createLighthouse(url, options = {}, config) {
   options.output = options.output || 'html'
   const log = options.logLevel ? require('lighthouse-logger') : null
@@ -17,20 +34,20 @@ module.exports = async function createLighthouse(url, options = {}, config) {
     log.setLevel(options.logLevel)
   }
   const chromeFlags = options.chromeFlags || defaultFlags
-  return chromium.puppeteer.launch({
-    args: chromeFlags,
-    executablePath: await chromium.executablePath,
-    headless: chromium.headless,
-    defaultViewport: chromium.defaultViewport,
-  })
-    .then((chrome) => {
-      options.port = new URL(chrome.wsEndpoint()).port
-      return {
-        chrome,
-        log,
-        start() {
-          return lighthouse(url, options, config)
-        }
-      }
-    })
+  console.log("path =" + chromePath)
+  if (!chromePath) { chromePath = await chromium.executablePath }
+  console.log("afterpath =" + chromePath)
+  let chrome = await chromeLauncher.launch({
+    chromeFlags, chromePath
+  });
+  console.log("before endpoint")
+  options.port = chrome.port
+  console.log("port: " + options.port)
+  const results = await lighthouse(url, options, config)
+  return {
+    chrome,
+    log,
+    results
+
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,41 +1,28 @@
 {
   "name": "lighthouse-lambda",
-  "version": "3.1.1",
+  "version": "5.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@serverless-chrome/lambda": {
-      "version": "1.0.0-54",
-      "resolved": "https://registry.npmjs.org/@serverless-chrome/lambda/-/lambda-1.0.0-54.tgz",
-      "integrity": "sha512-eCIvokokFE5z10IOP6v7fpg3ispCEEYwBw2kaJbLFIFeLIqg3YN7oxahKnvZ1pcAHbdaIgdxmBPXFzcaZqhzWA==",
-      "requires": {
-        "extract-zip": "1.6.6"
-      }
-    },
-    "@types/core-js": {
-      "version": "0.9.46",
-      "resolved": "https://registry.npmjs.org/@types/core-js/-/core-js-0.9.46.tgz",
-      "integrity": "sha512-LooLR6XHes9V+kNYRz1Qm8w3atw9QMn7XeZUmIpUelllF9BdryeUKd/u0Wh5ErcjpWfG39NrToU9MF7ngsTFVw=="
-    },
-    "@types/mkdirp": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.3.29.tgz",
-      "integrity": "sha1-fyrX7FX5FEgvybHsS7GuYCjUYGY="
+    "@types/mime-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
+      "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM="
     },
     "@types/node": {
-      "version": "9.6.23",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.23.tgz",
-      "integrity": "sha512-d2SJJpwkiPudEQ3+9ysANN2Nvz4QJKUPoe/WL5zyQzI0RaEeZWH5K5xjvUIGszTItHQpFPdH+u51f6G/LkS8Cg=="
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.0.tgz",
+      "integrity": "sha512-0ARSQootUG1RljH2HncpsY2TJBfGQIKOOi7kxzUY6z54ePu/ZD+wJA8zI2Q6v8rol2qpG/rvqsReco8zNMPvhQ=="
     },
-    "@types/rimraf": {
-      "version": "0.0.28",
-      "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-0.0.28.tgz",
-      "integrity": "sha1-VWJRm8eWPKyoq/fxKMrjtZTUHQY="
+    "JSV": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
+      "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
     },
     "acorn": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
       "dev": true
     },
     "acorn-jsx": {
@@ -54,6 +41,11 @@
           "dev": true
         }
       }
+    },
+    "agent-base": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
     },
     "ajv": {
       "version": "5.5.2",
@@ -108,11 +100,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-    },
     "array-includes": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
@@ -150,23 +137,43 @@
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
       "dev": true
     },
-    "async-limiter": {
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
+    "assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+    },
+    "aws4": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
+      "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
     "axe-core": {
-      "version": "3.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.0.0-beta.2.tgz",
-      "integrity": "sha512-JyMXnHDuzr6hei+mINWsR/iEyPBFSjpgF4/lUijO7QDGVKtTmdpDxc2+7X/xW+rPIwhcd72euJ2UunbRXF+1Eg=="
-    },
-    "babar": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/babar/-/babar-0.2.0.tgz",
-      "integrity": "sha512-bH01czBTWEbf7Q6qje/4raQEG14jhPTQJmpj1Uxzw92VCr9yQcCWN+SbKTg34aOvWDs6wrhjfr6SGC8AaeSzaA==",
-      "requires": {
-        "colors": "~0.6.2"
-      }
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.3.0.tgz",
+      "integrity": "sha512-54XaTd2VB7A6iBnXMUG2LnBOI7aRbnrVxC5Tz+rVUwYl9MX/cIJc/Ll32YUoFIE/e9UKWMZoQenQu9dFrQyZCg=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -226,6 +233,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -238,13 +253,6 @@
         "string-width": "^2.0.0",
         "term-size": "^1.2.0",
         "widest-line": "^2.0.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        }
       }
     },
     "brace-expansion": {
@@ -259,13 +267,13 @@
     "buffer-from": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
-      "dev": true
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
     },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
@@ -283,23 +291,24 @@
       "dev": true
     },
     "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+      "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
     },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "requires": {
-        "camelcase": "^2.0.0",
-        "map-obj": "^1.0.0"
-      }
+    "canonicalize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.1.tgz",
+      "integrity": "sha512-N3cmB3QLhS5TJ5smKFf1w42rJXWe6C1qP01z4dxJiI5v269buii4fLHWETDyf7yEd0azGLNC63VxNMiPd2u0Cg=="
     },
     "capture-stack-trace": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw=="
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "2.4.1",
@@ -321,30 +330,30 @@
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
     },
-    "chrome-devtools-frontend": {
-      "version": "1.0.422034",
-      "resolved": "https://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.422034.tgz",
-      "integrity": "sha1-BxyM4URmt2UwMvzRrRpKaNXjy9k="
+    "chrome-aws-lambda": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/chrome-aws-lambda/-/chrome-aws-lambda-2.1.1.tgz",
+      "integrity": "sha512-Wer2QuygxsCov5bM2+8CLa6qYpNsc5AxYTlgTne00aFoxFP491LGJRxOQtGnYtsJP6UG4pB0SfrwTyPnLys1Lw==",
+      "requires": {
+        "lambdafs": "^1.3.0"
+      }
     },
     "chrome-launcher": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.10.2.tgz",
-      "integrity": "sha512-E+kTHlGgtitPPu8Rci0E4XBasirKtTn6DjqFn8tTLp/7xCUzqb6lig9Il+HLkcudzKvT/aLxJbzbyNCe03w1AA==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.11.2.tgz",
+      "integrity": "sha512-jx0kJDCXdB2ARcDMwNCtrf04oY1Up4rOmVu+fqJ5MTPOOIG8EhRcEU9NZfXZc6dMw9FU8o1r21PNp8V2M0zQ+g==",
       "requires": {
-        "@types/core-js": "^0.9.41",
-        "@types/mkdirp": "^0.3.29",
-        "@types/node": "^9.3.0",
-        "@types/rimraf": "^0.0.28",
-        "is-wsl": "^1.1.0",
+        "@types/node": "*",
+        "is-wsl": "^2.1.0",
         "lighthouse-logger": "^1.0.0",
         "mkdirp": "0.5.1",
         "rimraf": "^2.6.1"
       }
     },
     "ci-info": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
     },
     "circular-json": {
       "version": "0.3.3",
@@ -437,10 +446,13 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
-    "colors": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
-      "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -451,7 +463,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -522,12 +533,25 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+    "cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
+    },
+    "cssstyle": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.2.1.tgz",
+      "integrity": "sha512-7DYm8qe+gPx/h77QlCyFmX80+fGaE/6A/Ekl0zaszYOubvySO2saYFdQ78P29D0UsULxFKCetDGNaNRUdSF+2A==",
       "requires": {
-        "array-find-index": "^1.0.1"
+        "cssom": "0.3.x"
+      }
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -607,21 +631,15 @@
         }
       }
     },
-    "devtools-timeline-model": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/devtools-timeline-model/-/devtools-timeline-model-1.1.6.tgz",
-      "integrity": "sha1-e+Uac7VdcntZe7MN0e0ujiEGOaU=",
-      "requires": {
-        "chrome-devtools-frontend": "1.0.401423",
-        "resolve": "1.1.7"
-      },
-      "dependencies": {
-        "chrome-devtools-frontend": {
-          "version": "1.0.401423",
-          "resolved": "https://registry.npmjs.org/chrome-devtools-frontend/-/chrome-devtools-frontend-1.0.401423.tgz",
-          "integrity": "sha1-MqibjQTjeKSUvjyNYycXA74cBOo="
-        }
-      }
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "details-element-polyfill": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/details-element-polyfill/-/details-element-polyfill-2.4.0.tgz",
+      "integrity": "sha512-jnZ/m0+b1gz3EcooitqL7oDEkKHEro659dt8bWB/T/HjiILucoQhHvvi5MEOAIFJXxxO+rIYJ/t3qCgfUOSU5g=="
     },
     "doctrine": {
       "version": "2.1.0",
@@ -645,6 +663,15 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
     },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "encoding": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
@@ -658,6 +685,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -957,9 +985,10 @@
       }
     },
     "esprima": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esquery": {
       "version": "1.0.1",
@@ -1005,6 +1034,11 @@
         "strip-eof": "^1.0.0"
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "external-editor": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
@@ -1016,35 +1050,20 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.6.tgz",
-      "integrity": "sha1-EpDt6NINCHK0Kf0/NRyhKOxe+Fw=",
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
       "requires": {
-        "concat-stream": "1.6.0",
+        "concat-stream": "1.6.2",
         "debug": "2.6.9",
-        "mkdirp": "0.5.0",
+        "mkdirp": "0.5.1",
         "yauzl": "2.4.1"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-          "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
-          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        }
       }
+    },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -1055,8 +1074,7 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -1115,6 +1133,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
       "requires": {
         "path-exists": "^2.0.0",
         "pinkie-promise": "^2.0.0"
@@ -1138,6 +1157,21 @@
       "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1155,15 +1189,18 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
-    },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.2",
@@ -1214,10 +1251,65 @@
         }
       }
     },
+    "got": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "requires": {
+        "create-error-class": "^3.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "safe-buffer": "^5.0.1",
+        "timed-out": "^4.0.0",
+        "unzip-response": "^2.0.1",
+        "url-parse-lax": "^1.0.0"
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+    },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
+          "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
+          "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        }
+      }
     },
     "has": {
       "version": "1.0.1",
@@ -1253,12 +1345,47 @@
     "hosted-git-info": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
+      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "dev": true
     },
     "http-link-header": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-0.8.0.tgz",
       "integrity": "sha1-oitBoMmx4tj6wb8baXxr1TLV9eQ="
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
+      "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
+      "requires": {
+        "agent-base": "5",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "iconv-lite": {
       "version": "0.4.21",
@@ -1288,14 +1415,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-    },
-    "indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "requires": {
-        "repeating": "^2.0.0"
-      }
     },
     "inflight": {
       "version": "1.0.6",
@@ -1337,6 +1456,32 @@
         "through": "^2.3.6"
       }
     },
+    "intl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/intl/-/intl-1.2.5.tgz",
+      "integrity": "sha1-giRKIZDE5Bn4Nx9ao02qNCDiq94="
+    },
+    "intl-messageformat": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-4.4.0.tgz",
+      "integrity": "sha512-z+Bj2rS3LZSYU4+sNitdHrwnBhr0wO80ZJSW8EzKDBowwUe3Q/UsvgCGjrwa+HPzoGCLEb9HAjfJgo4j2Sac8w==",
+      "requires": {
+        "intl-messageformat-parser": "^1.8.1"
+      }
+    },
+    "intl-messageformat-parser": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat-parser/-/intl-messageformat-parser-1.8.1.tgz",
+      "integrity": "sha512-IMSCKVf0USrM/959vj3xac7s8f87sc+80Y/ipBzdKy4ifBv5Gsj2tZ41EAaURVg01QU71fYr77uA8Meh6kELbg=="
+    },
+    "intl-pluralrules": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/intl-pluralrules/-/intl-pluralrules-1.1.2.tgz",
+      "integrity": "sha512-awT+Y/f7ftsg8IUfxRotCYFnDdmpFJQqud1jkOw8RAOUjslbhSC+xJoG4pqj/X8casKgAlQttnsbQP3R0BICyQ==",
+      "requires": {
+        "make-plural": "^6.1.0"
+      }
+    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -1345,7 +1490,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -1356,6 +1502,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
       "requires": {
         "builtin-modules": "^1.0.0"
       }
@@ -1367,11 +1514,11 @@
       "dev": true
     },
     "is-ci": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
-      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
+      "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "requires": {
-        "ci-info": "^1.0.0"
+        "ci-info": "^1.5.0"
       }
     },
     "is-date-object": {
@@ -1379,14 +1526,6 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
-    },
-    "is-finite": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -1461,9 +1600,9 @@
       "dev": true
     },
     "is-retry-allowed": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -1476,15 +1615,15 @@
       "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
-    "is-utf8": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-wsl": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
-      "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+      "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -1506,15 +1645,20 @@
         "whatwg-fetch": ">=0.10.0"
       }
     },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
     "jpeg-js": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
       "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4="
     },
     "js-library-detector": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-4.3.1.tgz",
-      "integrity": "sha1-bTT1UAKBO8CnVD3u9T+qTi55dns="
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/js-library-detector/-/js-library-detector-5.8.0.tgz",
+      "integrity": "sha512-7H10W+oukLGvs5gT5SeMjqYX03rglIQt3ggXzRiQxveUkVupHhbrd2mGPTKQ87bxSvMzlnAMdExfCDnquUi93Q=="
     },
     "js-tokens": {
       "version": "3.0.2",
@@ -1523,20 +1667,30 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
-      "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
@@ -1550,6 +1704,63 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "jsonld": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-1.8.1.tgz",
+      "integrity": "sha512-f0rusl5v8aPKS3jApT5fhYsdTC/JpyK1PoJ+ZtYYtZXoyb1J0Z///mJqLwrfL/g4NueFSqPymDYIi1CcSk7b8Q==",
+      "requires": {
+        "canonicalize": "^1.0.1",
+        "rdf-canonize": "^1.0.2",
+        "request": "^2.88.0",
+        "semver": "^5.6.0",
+        "xmldom": "0.1.19"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "jsonlint-mod": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/jsonlint-mod/-/jsonlint-mod-1.7.5.tgz",
+      "integrity": "sha512-VqTFtMj9JXv4qGSfcoYTgXgsGkTW4aXZer8u4vR64RAPjK37BUkNKmd3mTjuRTs1vQrE+yuzfzDhgB2SAyPvlA==",
+      "requires": {
+        "JSV": "^4.0.2",
+        "chalk": "^2.4.2",
+        "underscore": "^1.9.1"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
+    },
     "jsx-ast-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
@@ -1557,6 +1768,117 @@
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3"
+      }
+    },
+    "lambdafs": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/lambdafs/-/lambdafs-1.3.0.tgz",
+      "integrity": "sha512-HqRPmEgtkTW4sCYDUjTEuTGkjCHuLvtZU8iM8GkhD7SpjW4AJJbBk86YU4K43sWGuW5Vmzp1lVCx4ab/kJsuBw==",
+      "requires": {
+        "tar-fs": "^2.0.0"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "^3.0.1"
+          }
+        },
+        "chownr": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "once": "^1.4.0"
+          }
+        },
+        "fs-constants": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1"
+          }
+        },
+        "pump": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.0",
+          "bundled": true
+        },
+        "string_decoder": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "~5.2.0"
+          }
+        },
+        "tar-fs": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "chownr": "^1.1.1",
+            "mkdirp": "^0.5.1",
+            "pump": "^3.0.0",
+            "tar-stream": "^2.0.0"
+          }
+        },
+        "tar-stream": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "bl": "^3.0.0",
+            "end-of-stream": "^1.4.1",
+            "fs-constants": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1"
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
       }
     },
     "latest-version": {
@@ -1586,62 +1908,51 @@
       }
     },
     "lighthouse": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-3.0.3.tgz",
-      "integrity": "sha512-RlHdCRUYCqM22LG/1aGKvyqAfU4alCmVMp65YJhrP39lC2KWU4DyY1JOKu7FGq16fHDEE+vvPsgSaRjS/GTbTA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-5.6.0.tgz",
+      "integrity": "sha512-PQYeK6/P0p/JxP/zq8yfcPmuep/aeib5ykROTgzDHejMiuzYdD6k6MaSCv0ncwK+lj+Ld67Az+66rHqiPKHc6g==",
       "requires": {
-        "axe-core": "3.0.0-beta.2",
-        "chrome-devtools-frontend": "1.0.422034",
-        "chrome-launcher": "^0.10.2",
+        "axe-core": "3.3.0",
+        "chrome-launcher": "^0.11.2",
         "configstore": "^3.1.1",
-        "devtools-timeline-model": "1.1.6",
-        "esprima": "^4.0.0",
+        "cssstyle": "1.2.1",
+        "details-element-polyfill": "^2.4.0",
         "http-link-header": "^0.8.0",
         "inquirer": "^3.3.0",
+        "intl": "^1.2.5",
+        "intl-messageformat": "^4.4.0",
+        "intl-pluralrules": "^1.0.3",
         "jpeg-js": "0.1.2",
-        "js-library-detector": "^4.3.1",
-        "lighthouse-logger": "^1.0.0",
+        "js-library-detector": "^5.5.0",
+        "jsonld": "^1.5.0",
+        "jsonlint-mod": "^1.7.5",
+        "lighthouse-logger": "^1.2.0",
         "lodash.isequal": "^4.5.0",
+        "lodash.set": "^4.3.2",
+        "lookup-closest-locale": "6.0.4",
         "metaviewport-parser": "0.2.0",
         "mkdirp": "0.5.1",
-        "opn": "4.0.2",
+        "open": "^6.4.0",
         "parse-cache-control": "1.0.1",
         "raven": "^2.2.1",
         "rimraf": "^2.6.1",
         "robots-parser": "^2.0.1",
         "semver": "^5.3.0",
-        "speedline": "1.3.3",
-        "update-notifier": "^2.1.0",
+        "speedline-core": "1.4.2",
+        "third-party-web": "^0.11.0",
+        "update-notifier": "^2.5.0",
         "ws": "3.3.2",
         "yargs": "3.32.0",
         "yargs-parser": "7.0.0"
       }
     },
     "lighthouse-logger": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.0.1.tgz",
-      "integrity": "sha1-8HPYP3rLyWcpvxAKEhyPAGmRrmE=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lighthouse-logger/-/lighthouse-logger-1.2.0.tgz",
+      "integrity": "sha512-wzUvdIeJZhRsG6gpZfmSCfysaxNEr43i+QT+Hie94wvHDKFLi4n7C2GqZ4sTC+PH5b5iktmXJvU87rWvhP3lHw==",
       "requires": {
-        "debug": "^2.6.8"
-      }
-    },
-    "load-json-file": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
+        "debug": "^2.6.8",
+        "marky": "^1.2.0"
       }
     },
     "locate-path": {
@@ -1663,14 +1974,24 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+    },
+    "lookup-closest-locale": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/lookup-closest-locale/-/lookup-closest-locale-6.0.4.tgz",
+      "integrity": "sha512-bWoFbSGe6f1GvMGzj17LrwMX4FhDXDwZyH04ySVCPbtOJADcSRguZNKewoJ3Ful/MOxD/wRHvFPadk/kYZUbuQ=="
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -1679,15 +2000,6 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0"
-      }
-    },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "requires": {
-        "currently-unhandled": "^0.4.1",
-        "signal-exit": "^3.0.0"
       }
     },
     "lowercase-keys": {
@@ -1712,10 +2024,15 @@
         "pify": "^3.0.0"
       }
     },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+    "make-plural": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/make-plural/-/make-plural-6.1.0.tgz",
+      "integrity": "sha512-0ekbPHqxcdRcmjZ43TkRuejK5rXgMF1OjG4FVnVHgCvOcjrexaSX7a0dfAvqhOm1qWPgjYnXtmz3cHpHW5ZewA=="
+    },
+    "marky": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/marky/-/marky-1.2.1.tgz",
+      "integrity": "sha512-md9k+Gxa3qLH6sUKpeC2CNkJK/Ld+bEz5X96nYwloqphQE0CKCVEKco/6jxEZixinqNdz5RFi/KaCyfbMDMAXQ=="
     },
     "md5": {
       "version": "2.2.1",
@@ -1727,34 +2044,28 @@
         "is-buffer": "~1.1.1"
       }
     },
-    "meow": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "requires": {
-        "camelcase-keys": "^2.0.0",
-        "decamelize": "^1.1.2",
-        "loud-rejection": "^1.0.0",
-        "map-obj": "^1.0.1",
-        "minimist": "^1.1.3",
-        "normalize-package-data": "^2.3.4",
-        "object-assign": "^4.0.1",
-        "read-pkg-up": "^1.0.1",
-        "redent": "^1.0.0",
-        "trim-newlines": "^1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
-    },
     "metaviewport-parser": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/metaviewport-parser/-/metaviewport-parser-0.2.0.tgz",
       "integrity": "sha1-U1w84cz2IjpQJf3cahw2UF9+fbE="
+    },
+    "mime": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+      "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+    },
+    "mime-db": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+    },
+    "mime-types": {
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "requires": {
+        "mime-db": "1.43.0"
+      }
     },
     "mimic-fn": {
       "version": "1.2.0",
@@ -1808,10 +2119,16 @@
         "is-stream": "^1.0.1"
       }
     },
+    "node-forge": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
+      "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
         "is-builtin-module": "^1.0.0",
@@ -1832,10 +2149,16 @@
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-keys": {
       "version": "1.0.11",
@@ -1859,13 +2182,19 @@
         "mimic-fn": "^1.0.0"
       }
     },
-    "opn": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
-      "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+    "open": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+      "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
       "requires": {
-        "object-assign": "^4.0.1",
-        "pinkie-promise": "^2.0.0"
+        "is-wsl": "^1.1.0"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+          "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+        }
       }
     },
     "optionator": {
@@ -1933,39 +2262,6 @@
         "registry-auth-token": "^3.0.1",
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
-      },
-      "dependencies": {
-        "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          }
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
-        },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-          "requires": {
-            "prepend-http": "^1.0.1"
-          }
-        }
       }
     },
     "parse-cache-control": {
@@ -1977,6 +2273,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
       }
@@ -1985,6 +2282,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
       "requires": {
         "pinkie-promise": "^2.0.0"
       }
@@ -2010,27 +2308,15 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
     },
-    "path-type": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-        }
-      }
-    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "pify": {
       "version": "3.0.0",
@@ -2040,12 +2326,14 @@
     "pinkie": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
       "requires": {
         "pinkie": "^2.0.0"
       }
@@ -2131,6 +2419,11 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+    },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -2162,21 +2455,93 @@
         "object-assign": "^4.1.1"
       }
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "psl": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+      "integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "puppeteer-core": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-2.1.1.tgz",
+      "integrity": "sha512-n13AWriBMPYxnpbb6bnaY5YoY6rGj8vPLrz6CZF3o0qJNEwlcfJVxBzYZ0NJsQ21UbdJoijPCDrM++SUVEz7+w==",
+      "requires": {
+        "@types/mime-types": "^2.1.0",
+        "debug": "^4.1.0",
+        "extract-zip": "^1.6.6",
+        "https-proxy-agent": "^4.0.0",
+        "mime": "^2.0.3",
+        "mime-types": "^2.1.25",
+        "progress": "^2.0.1",
+        "proxy-from-env": "^1.0.0",
+        "rimraf": "^2.6.1",
+        "ws": "^6.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "progress": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+          "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+        },
+        "ws": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+          "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+          "requires": {
+            "async-limiter": "~1.0.0"
+          }
+        }
+      }
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
     "raven": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.3.tgz",
-      "integrity": "sha512-bKre7qlDW+y1+G2bUtCuntdDYc8o5v1T233t0vmJfbj8ttGOgLrGRlYB8saelVMW9KUAJNLrhFkAKOwFWFJonw==",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
+      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
       "requires": {
         "cookie": "0.3.1",
         "md5": "^2.2.1",
         "stack-trace": "0.0.10",
         "timed-out": "4.0.1",
-        "uuid": "3.0.0"
+        "uuid": "3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
       }
     },
     "rc": {
@@ -2191,29 +2556,26 @@
       },
       "dependencies": {
         "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.4.tgz",
+          "integrity": "sha512-wTiNDqe4D2rbTJGZk1qcdZgFtY0/r+iuE6GDT7V0/+Gu5MLpIDm4+CssDECR79OJs/OxLPXMzdxy153b5Qy3hg=="
         }
       }
     },
-    "read-pkg": {
+    "rdf-canonize": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-1.1.0.tgz",
+      "integrity": "sha512-DV06OnhVfl2zcZJQCt+YvU+hoZVgpyQpNFLeAmghq8RJybUxD3B4LRzlBquYS5k+LLd8/c3g5Gnhkqjw5qRMvg==",
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
-      }
-    },
-    "read-pkg-up": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-      "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "node-forge": "^0.9.1",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        }
       }
     },
     "readable-stream": {
@@ -2230,19 +2592,10 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "redent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "requires": {
-        "indent-string": "^2.1.0",
-        "strip-indent": "^1.0.1"
-      }
-    },
     "registry-auth-token": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
-      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "requires": {
         "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
@@ -2256,12 +2609,31 @@
         "rc": "^1.0.1"
       }
     },
-    "repeating": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+    "request": {
+      "version": "2.88.2",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
-        "is-finite": "^1.0.0"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.5.0",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       }
     },
     "require-uncached": {
@@ -2273,11 +2645,6 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
-    },
-    "resolve": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -2303,9 +2670,9 @@
       }
     },
     "robots-parser": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-2.1.0.tgz",
-      "integrity": "sha512-k07MeDS1Tl1zjoYs5bHfUbgQ0MfaeTOepDcjZFxdYXd84p6IeLDQyUwlMk2AZ9c2yExA30I3ayWhmqz9tg0DzQ=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-2.1.1.tgz",
+      "integrity": "sha512-6yWEYSdhK3bAEcYY0In3wgSBK70BiQoJArzdjZKCP/35b3gKIYu5Lc0qQqsoxjoLVebVoJiKK4VWGc5+oxvWBQ=="
     },
     "run-async": {
       "version": "2.3.0",
@@ -2394,6 +2761,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+      "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
@@ -2402,12 +2770,14 @@
     "spdx-exceptions": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
-      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+      "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -2416,19 +2786,17 @@
     "spdx-license-ids": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
-      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
+      "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+      "dev": true
     },
-    "speedline": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/speedline/-/speedline-1.3.3.tgz",
-      "integrity": "sha512-VyBYEbYE2Pm15+mdnb1bfdbMTkxQ8UqqD21p9ynyZlmYELoDX6PFAxy7g2aWukXWljK6LOiyCDCLphcsX+DXGA==",
+    "speedline-core": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/speedline-core/-/speedline-core-1.4.2.tgz",
+      "integrity": "sha512-9/5CApkKKl6bS6jJ2D0DQllwz/1xq3cyJCR6DLgAQnkj5djCuq8NbflEdD2TI01p8qzS9qaKjzxM9cHT11ezmg==",
       "requires": {
         "@types/node": "*",
-        "babar": "0.2.0",
         "image-ssim": "^0.2.0",
-        "jpeg-js": "^0.1.2",
-        "loud-rejection": "^1.6.0",
-        "meow": "^3.7.0"
+        "jpeg-js": "^0.1.2"
       }
     },
     "sprintf-js": {
@@ -2436,6 +2804,22 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -2510,26 +2894,10 @@
         "ansi-regex": "^3.0.0"
       }
     },
-    "strip-bom": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-      "requires": {
-        "is-utf8": "^0.2.0"
-      }
-    },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
-    },
-    "strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "requires": {
-        "get-stdin": "^4.0.1"
-      }
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -2572,6 +2940,11 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "third-party-web": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/third-party-web/-/third-party-web-0.11.1.tgz",
+      "integrity": "sha512-PBS478cWhvCM8seuloomV5lGHvu2qMOCj8gq8wKOApdfAaGh9l2rYZkdsBDaQyQg/6plov3uodc6sZ/3c1lu/g=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -2590,10 +2963,27 @@
         "os-tmpdir": "~1.0.2"
       }
     },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+    "tough-cookie": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+      "requires": {
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "type-check": {
       "version": "0.3.2",
@@ -2619,6 +3009,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+    },
+    "underscore": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
     },
     "uniq": {
       "version": "1.0.1",
@@ -2656,23 +3051,50 @@
         "xdg-basedir": "^3.0.0"
       }
     },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "requires": {
+        "prepend-http": "^1.0.1"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
-      "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "validate-npm-package-license": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+      "dev": true,
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "whatwg-fetch": {
@@ -2690,9 +3112,9 @@
       }
     },
     "widest-line": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
-      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.1.tgz",
+      "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "requires": {
         "string-width": "^2.1.1"
       }
@@ -2765,9 +3187,9 @@
       }
     },
     "write-file-atomic": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-      "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "requires": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
@@ -2788,6 +3210,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+    },
+    "xmldom": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.19.tgz",
+      "integrity": "sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw="
     },
     "xtend": {
       "version": "4.0.1",
@@ -2824,6 +3251,11 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+        },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -2858,13 +3290,6 @@
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "requires": {
         "camelcase": "^4.1.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-        }
       }
     },
     "yauzl": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://github.com/AlanSwenson/lighthouse-lambda#readme",
   "dependencies": {
-    "@serverless-chrome/lambda": "^1.0.0-54",
+    "chrome-aws-lambda": "^2.1.1",
     "lighthouse": "^3.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "lighthouse-lambda",
-  "version": "3.1.1",
+  "version": "5.6.0",
   "description": "Run Google Chrome Lighthouse on AWS Lambda.",
   "engines": {
-    "node": "10.x"
+    "node": "12.x"
   },
   "main": "lib/index.js",
   "files": [
@@ -38,7 +38,8 @@
   "homepage": "https://github.com/AlanSwenson/lighthouse-lambda#readme",
   "dependencies": {
     "chrome-aws-lambda": "^2.1.1",
-    "lighthouse": "^5.6.0"
+    "lighthouse": "^5.6.0",
+    "puppeteer-core": "^2.1.1"
   },
   "devDependencies": {
     "standard": "^11.0.1"

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
   "scripts": {
     "lint": "standard --fix",
     "pretest": "standard",
-    "build:install": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:build-nodejs10.x bash -c \"rm -rf node_modules && npm install\"",
-    "build": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:build-nodejs10.x bash -c \"rm -f *.zip && zip lighthouse-lambda.zip -r lib node_modules bin test.js package.json\"",
-    "test": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:nodejs10.x test.handler '{}'",
-    "test:results": "docker run --rm -v \"$PWD\":/var/task --user root lambci/lambda:nodejs10.x test.handler '{\"saveResults\":true}'"
+    "build:install": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:build-nodejs12.x bash -c \"rm -rf node_modules && npm install\"",
+    "build": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:build-nodejs12.x bash -c \"rm -f *.zip && zip lighthouse-lambda.zip -r lib node_modules bin test.js package.json\"",
+    "test": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:nodejs12.x test.handler '{}'",
+    "test:results": "docker run --rm -v \"$PWD\":/var/task --user root lambci/lambda:nodejs12.x test.handler '{\"saveResults\":true}'"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "homepage": "https://github.com/AlanSwenson/lighthouse-lambda#readme",
   "dependencies": {
     "chrome-aws-lambda": "^2.1.1",
-    "lighthouse": "^3.0.3"
+    "lighthouse": "^5.6.0"
   },
   "devDependencies": {
     "standard": "^11.0.1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.1",
   "description": "Run Google Chrome Lighthouse on AWS Lambda.",
   "engines": {
-    "node": "8.10.x"
+    "node": "10.x"
   },
   "main": "lib/index.js",
   "files": [
@@ -12,10 +12,10 @@
   "scripts": {
     "lint": "standard --fix",
     "pretest": "standard",
-    "build:install": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:build-nodejs8.10 bash -c \"rm -rf node_modules && npm install\"",
-    "build": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:build-nodejs8.10 bash -c \"rm -f *.zip && zip lighthouse-lambda.zip -r lib node_modules bin test.js package.json\"",
-    "test": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:nodejs8.10 test.handler '{}'",
-    "test:results": "docker run --rm -v \"$PWD\":/var/task --user root lambci/lambda:nodejs8.10 test.handler '{\"saveResults\":true}'"
+    "build:install": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:build-nodejs10.x bash -c \"rm -rf node_modules && npm install\"",
+    "build": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:build-nodejs10.x bash -c \"rm -f *.zip && zip lighthouse-lambda.zip -r lib node_modules bin test.js package.json\"",
+    "test": "docker run --rm -v \"$PWD\":/var/task lambci/lambda:nodejs10.x test.handler '{}'",
+    "test:results": "docker run --rm -v \"$PWD\":/var/task --user root lambci/lambda:nodejs10.x test.handler '{\"saveResults\":true}'"
   },
   "repository": {
     "type": "git",
@@ -30,12 +30,12 @@
     "serverless",
     "devtools"
   ],
-  "author": "JoyToCode <team@joytocode.com>",
+  "author": "JoyToCode <team@joytocode.com>, forked by AlanSwenson <alan@alanswenson.dev>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/joytocode/lighthouse-lambda/issues"
+    "url": "https://github.com/AlanSwenson/lighthouse-lambda"
   },
-  "homepage": "https://github.com/joytocode/lighthouse-lambda#readme",
+  "homepage": "https://github.com/AlanSwenson/lighthouse-lambda#readme",
   "dependencies": {
     "@serverless-chrome/lambda": "^1.0.0-54",
     "lighthouse": "^3.0.3"

--- a/results/5.6.0.html
+++ b/results/5.6.0.html
@@ -1,0 +1,6741 @@
+<!--
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+  <link rel="icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAEhklEQVR4AWJxL/BhIAesev1U5tcflpncgNrKIsqNIwzC9feMpDUzs70kOczMzMzJJcxwCTMzncPMnOwtzBwzMzPb0vRfeZPp0VhPS5I39V5fdiXV1/VD+9QC7OVn9BsyH1XIoEI1PfmJvLFowVV564+34DFUHudbmfDh4kVXh//7XwE+WjS/YfXZe3yr4j2rqj1AIhSB7hZ8ZtPZu/zw8cK523U4wE1/rvPfWrz4zs0m9ZdC9yUJAlASdBAgocRegfF/f3/h/PuaFsxMdwjAR0vm1+06eMMfIrhLqTWqdH4EumU2SPfMhigJAlRQbZrgrRsl9U+Y2DYDFCz3ILC9kiAiqSrMwbWT0nceEnR+9Kggc2zjOJCASDENkg0a5HfZZgDP81CM3CrQs2Z1+o7DJ6ePr8sK0AOCHv5Jjdt3evyYSaZ351VIStIxPRAUtrBYbxC6w+BZ0ivVSBKkIhJhemSyZpfB00EiPO2VjzYkxhcqXQqCWCShGplvi3y0QxqbuBurMjyJeWnkHZuAEgIQGsUBqwrfjZ+IlBgKyRJzVVYF8O6qFWdh86YzQzMrZigYmxAyfvHgLZQ/LC1CbeniW2Hkqr/PH16SgvGuf2/uzNMBwJA/njxizGPtSyAf7EziJCMGRDRdhoAC4PL1A/SrKQMAAQkEfpJAcRQdrBJ7gNwjSpJsdwK+CANBkqa1LgQB4IicV9nYUct7gaxuDJUErQIiEAiMxLVOFlKzIktPpT0ggpdpC/8YAHnxbgkUY4tAAFSR7AAXNyAAWHJrA/kHGjzg5nleuwFO7Nd/IoDw4Pm58+4jNLmYG0wRA5bErc2Mr3Y+dXTDW1VvwqbJkzMCHQ4S1GTCBOIgUHJrGdEwqzR+jAp/o2qAZelUDoQnruEEdDclJI6576AlNVfc+22XN/+Y1vnJD0Yind6UpEEvn/Hqq15EYjCW7jZCJEpnNvDgkyelDjs106kuux2AAXCSobULOWP8mLhYlpoDMK4qAFXJGk+grtH8YXVz5KJblqaG1+VUdTc0I290bmUQAriGITRbdQnom0aoFj8kx1+wMD2ifncAXUQE4SkDqN1hE0jEophs1SUwZAOhUAiMCLwRtamtTZtbbmZErSAUHbSysaoEmnrsakiMiUAURi283gN6wans9oX8rOCrj7/JP35DFD+iQ7Au/K2KE1jzx6ujjUnXFH9KjEq6ZlhsTBICrNLJf47Pv/pkHzvup1w4dmUbEei0+bcXRqJuh5kVARQ8byyYxOwNGr7A87xh1tp8sGT+uMInrwi++Xj7TQz2d27NvwEkrOflAFQGIDA5khASBCGdO2/Z/MnLPwYfv5TFhjW7QhVKAB6afwe2LpFlFsCnlQEosgQgDsdOG1/LKeNqJS4JCSPJ/i+TakwEARor7gER1Iva5JmPOJK0RUqmoPnnlzFCtmIAhAAQEIQRgDaiYPIauNXcnDlRIrWNFY3hm7PG9YRqr7IV7HrCgAC17befjEvRq2nGhAHtBqDpOuI/I1diUUAMYIxEdyejBJqLnNoszGZtfiX/CztGv2mq+sdaAAAAAElFTkSuQmCC">
+  <title>Lighthouse Report</title>
+  <style>/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+  Naming convention:
+
+  If a variable is used for a specific component: --{component}-{property name}-{modifier}
+
+  Both {component} and {property name} should be kebab-case. If the target is the entire page,
+  use 'report' for the component. The property name should not be abbreviated. Use the
+  property name the variable is intended for - if it's used for multiple, a common descriptor
+  is fine (ex: 'size' for a variable applied to 'width' and 'height'). If a variable is shared
+  across multiple components, either create more variables or just drop the "{component}-"
+  part of the name. Append any modifiers at the end (ex: 'big', 'dark').
+
+  For colors: --color-{hue}-{intensity}
+
+  {intensity} is the Material Design tag - 700, A700, etc.
+*/
+.lh-vars {
+  /* Palette using Material Design Colors
+   * https://www.materialui.co/colors */
+  --color-amber-50: #FFF8E1;
+  --color-blue-200: #90CAF9;
+  --color-blue-900: #0D47A1;
+  --color-blue-A700: #2962FF;
+  --color-cyan-500: #00BCD4;
+  --color-gray-100: #F5F5F5;
+  --color-gray-200: #E0E0E0;
+  --color-gray-400: #BDBDBD;
+  --color-gray-50: #FAFAFA;
+  --color-gray-500: #9E9E9E;
+  --color-gray-600: #757575;
+  --color-gray-700: #616161;
+  --color-gray-800: #424242;
+  --color-gray-900: #212121;
+  --color-gray: #000000;
+  --color-green-700: #018642;
+  --color-green: #0CCE6B;
+  --color-orange-700: #D04900;
+  --color-orange: #FFA400;
+  --color-red-700: #EB0F00;
+  --color-red: #FF4E42;
+  --color-teal-600: #00897B;
+  --color-white: #FFFFFF;
+
+  /* Context-specific colors */
+  --color-average-secondary: var(--color-orange-700);
+  --color-average: var(--color-orange);
+  --color-fail-secondary: var(--color-red-700);
+  --color-fail: var(--color-red);
+  --color-informative: var(--color-blue-900);
+  --color-pass-secondary: var(--color-green-700);
+  --color-pass: var(--color-green);
+  --color-hover: var(--color-gray-50);
+
+  /* Component variables */
+  --audit-description-padding-left: calc(var(--score-icon-size) + var(--score-icon-margin-left) + var(--score-icon-margin-right));
+  --audit-explanation-line-height: 16px;
+  --audit-group-margin-bottom: 40px;
+  --audit-group-padding-vertical: 8px;
+  --audit-margin-horizontal: 5px;
+  --audit-padding-vertical: 8px;
+  --category-header-font-size: 20px;
+  --category-padding: 40px;
+  --chevron-line-stroke: var(--color-gray-600);
+  --chevron-size: 12px;
+  --default-padding: 12px;
+  --env-item-background-color: var(--color-gray-100);
+  --env-item-font-size: 28px;
+  --env-item-line-height: 36px;
+  --env-item-padding: 10px 0px;
+  --env-name-min-width: 220px;
+  --footer-padding-vertical: 16px;
+  --gauge-circle-size-big: 112px;
+  --gauge-circle-size: 80px;
+  --gauge-label-font-size-big: 28px;
+  --gauge-label-font-size: 20px;
+  --gauge-label-line-height-big: 36px;
+  --gauge-label-line-height: 26px;
+  --gauge-percentage-font-size-big: 38px;
+  --gauge-percentage-font-size: 28px;
+  --gauge-wrapper-width: 148px;
+  --header-line-height: 24px;
+  --highlighter-background-color: var(--report-text-color);
+  --icon-square-size: calc(var(--score-icon-size) * 0.88);
+  --image-preview-size: 48px;
+  --metric-toggle-lines-fill: #7F7F7F;
+  --metrics-toggle-background-color: var(--color-gray-200);
+  --plugin-badge-background-color: var(--color-white);
+  --plugin-badge-size-big: calc(var(--gauge-circle-size-big) / 2.7);
+  --plugin-badge-size: calc(var(--gauge-circle-size) / 2.7);
+  --plugin-icon-size: 65%;
+  --pwa-icon-margin: 0 6px 0 -2px;
+  --pwa-icon-size: var(--topbar-logo-size);
+  --report-background-color: #fff;
+  --report-border-color-secondary: #ebebeb;
+  --report-font-family-monospace: 'Roboto Mono', 'Menlo', 'dejavu sans mono', 'Consolas', 'Lucida Console', monospace;
+  --report-font-family: Roboto, Helvetica, Arial, sans-serif;
+  --report-font-size: 16px;
+  --report-line-height: 24px;
+  --report-min-width: 400px;
+  --report-text-color-secondary: var(--color-gray-800);
+  --report-text-color: var(--color-gray-900);
+  --report-width: calc(60 * var(--report-font-size));
+  --score-container-padding: 8px;
+  --score-icon-background-size: 24px;
+  --score-icon-margin-left: 4px;
+  --score-icon-margin-right: 12px;
+  --score-icon-margin: 0 var(--score-icon-margin-right) 0 var(--score-icon-margin-left);
+  --score-icon-size: 12px;
+  --scores-container-padding: 20px 0 20px 0;
+  --scorescale-height: 6px;
+  --scorescale-width: 18px;
+  --section-padding-vertical: 12px;
+  --snippet-background-color: var(--color-gray-50);
+  --snippet-color: var(--color-gray-800);
+  --sparkline-height: 5px;
+  --stackpack-padding-horizontal: 10px;
+  --sticky-header-background-color: var(--report-background-color);
+  --table-higlight-background-color: hsla(0, 0%, 75%, 0.1);
+  --tools-icon-color: var(--color-gray-600);
+  --tools-icon-size: var(--score-icon-background-size);
+  --topbar-background-color: var(--color-gray-100);
+  --topbar-height: 32px;
+  --topbar-logo-size: 24px;
+  --topbar-padding: 0 8px;
+  --toplevel-warning-padding: 22px;
+
+  /* SVGs */
+  --plugin-icon-url-dark: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="%23FFFFFF"><path d="M0 0h24v24H0z" fill="none"/><path d="M20.5 11H19V7c0-1.1-.9-2-2-2h-4V3.5C13 2.12 11.88 1 10.5 1S8 2.12 8 3.5V5H4c-1.1 0-1.99.9-1.99 2v3.8H3.5c1.49 0 2.7 1.21 2.7 2.7s-1.21 2.7-2.7 2.7H2V20c0 1.1.9 2 2 2h3.8v-1.5c0-1.49 1.21-2.7 2.7-2.7 1.49 0 2.7 1.21 2.7 2.7V22H17c1.1 0 2-.9 2-2v-4h1.5c1.38 0 2.5-1.12 2.5-2.5S21.88 11 20.5 11z"/></svg>');
+  --plugin-icon-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24" fill="%23757575"><path d="M0 0h24v24H0z" fill="none"/><path d="M20.5 11H19V7c0-1.1-.9-2-2-2h-4V3.5C13 2.12 11.88 1 10.5 1S8 2.12 8 3.5V5H4c-1.1 0-1.99.9-1.99 2v3.8H3.5c1.49 0 2.7 1.21 2.7 2.7s-1.21 2.7-2.7 2.7H2V20c0 1.1.9 2 2 2h3.8v-1.5c0-1.49 1.21-2.7 2.7-2.7 1.49 0 2.7 1.21 2.7 2.7V22H17c1.1 0 2-.9 2-2v-4h1.5c1.38 0 2.5-1.12 2.5-2.5S21.88 11 20.5 11z"/></svg>');
+
+  --pass-icon-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><title>check</title><path fill="%23178239" d="M24 4C12.95 4 4 12.95 4 24c0 11.04 8.95 20 20 20 11.04 0 20-8.96 20-20 0-11.05-8.96-20-20-20zm-4 30L10 24l2.83-2.83L20 28.34l15.17-15.17L38 16 20 34z"/></svg>');
+  --average-icon-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><title>info</title><path fill="%23E67700" d="M24 4C12.95 4 4 12.95 4 24s8.95 20 20 20 20-8.95 20-20S35.05 4 24 4zm2 30h-4V22h4v12zm0-16h-4v-4h4v4z"/></svg>');
+  --fail-icon-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48"><title>warn</title><path fill="%23C7221F" d="M2 42h44L24 4 2 42zm24-6h-4v-4h4v4zm0-8h-4v-8h4v8z"/></svg>');
+
+  --pwa-fast-reliable-gray-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="nonzero"><circle fill="%23DAE0E3" cx="12" cy="12" r="12"/><path d="M12.3 4l6.3 2.8V11c0 3.88-2.69 7.52-6.3 8.4C8.69 18.52 6 14.89 6 11V6.8L12.3 4zm-.56 12.88l3.3-5.79.04-.08c.05-.1.01-.29-.26-.29h-1.96l.56-3.92h-.56L9.6 12.52c0 .03.07-.12-.03.07-.11.2-.12.37.2.37h1.97l-.56 3.92h.56z" fill="%23FFF"/></g></svg>');
+  --pwa-installable-gray-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="nonzero"><circle fill="%23DAE0E3" cx="12" cy="12" r="12"/><path d="M12 5a7 7 0 1 0 0 14 7 7 0 0 0 0-14zm3.5 7.7h-2.8v2.8h-1.4v-2.8H8.5v-1.4h2.8V8.5h1.4v2.8h2.8v1.4z" fill="%23FFF"/></g></svg>');
+  --pwa-optimized-gray-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><rect fill="%23DAE0E3" width="24" height="24" rx="12"/><path fill="%23FFF" d="M12 15.07l3.6 2.18-.95-4.1 3.18-2.76-4.2-.36L12 6.17l-1.64 3.86-4.2.36 3.2 2.76-.96 4.1z"/><path d="M5 5h14v14H5z"/></g></svg>');
+
+  --pwa-fast-reliable-gray-url-dark: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="nonzero"><circle fill="%23424242" cx="12" cy="12" r="12"/><path d="M12.3 4l6.3 2.8V11c0 3.88-2.69 7.52-6.3 8.4C8.69 18.52 6 14.89 6 11V6.8L12.3 4zm-.56 12.88l3.3-5.79.04-.08c.05-.1.01-.29-.26-.29h-1.96l.56-3.92h-.56L9.6 12.52c0 .03.07-.12-.03.07-.11.2-.12.37.2.37h1.97l-.56 3.92h.56z" fill="%23FFF"/></g></svg>');
+  --pwa-installable-gray-url-dark: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="nonzero"><circle fill="%23424242" cx="12" cy="12" r="12"/><path d="M12 5a7 7 0 1 0 0 14 7 7 0 0 0 0-14zm3.5 7.7h-2.8v2.8h-1.4v-2.8H8.5v-1.4h2.8V8.5h1.4v2.8h2.8v1.4z" fill="%23FFF"/></g></svg>');
+  --pwa-optimized-gray-url-dark: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><rect fill="%23424242" width="24" height="24" rx="12"/><path fill="%23FFF" d="M12 15.07l3.6 2.18-.95-4.1 3.18-2.76-4.2-.36L12 6.17l-1.64 3.86-4.2.36 3.2 2.76-.96 4.1z"/><path d="M5 5h14v14H5z"/></g></svg>');
+
+  --pwa-fast-reliable-color-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><g fill-rule="nonzero" fill="none"><circle fill="%230CCE6B" cx="12" cy="12" r="12"/><path d="M12 4.3l6.3 2.8v4.2c0 3.88-2.69 7.52-6.3 8.4-3.61-.88-6.3-4.51-6.3-8.4V7.1L12 4.3zm-.56 12.88l3.3-5.79.04-.08c.05-.1.01-.29-.26-.29h-1.96l.56-3.92h-.56L9.3 12.82c0 .03.07-.12-.03.07-.11.2-.12.37.2.37h1.97l-.56 3.92h.56z" fill="%23FFF"/></g></svg>');
+  --pwa-installable-color-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><g fill-rule="nonzero" fill="none"><circle fill="%230CCE6B" cx="12" cy="12" r="12"/><path d="M12 5a7 7 0 1 0 0 14 7 7 0 0 0 0-14zm3.5 7.7h-2.8v2.8h-1.4v-2.8H8.5v-1.4h2.8V8.5h1.4v2.8h2.8v1.4z" fill="%23FFF"/></g></svg>');
+  --pwa-optimized-color-url: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><rect fill="%230CCE6B" width="24" height="24" rx="12"/><path d="M5 5h14v14H5z"/><path fill="%23FFF" d="M12 15.07l3.6 2.18-.95-4.1 3.18-2.76-4.2-.36L12 6.17l-1.64 3.86-4.2.36 3.2 2.76-.96 4.1z"/></g></svg>');
+}
+
+@media not print {
+  .lh-vars.dark {
+    /* Pallete */
+    --color-gray-200: var(--color-gray-800);
+    --color-gray-400: var(--color-gray-600);
+    --color-gray-50: #757575;
+    --color-gray-600: var(--color-gray-500);
+    --color-green-700: var(--color-green);
+    --color-orange-700: var(--color-orange);
+    --color-red-700: var(--color-red);
+    --color-teal-600: var(--color-cyan-500);
+
+    /* Context-specific colors */
+    --color-hover: rgba(0, 0, 0, 0.2);
+    --color-informative: var(--color-blue-200);
+
+    /* Component variables */
+    --env-item-background-color: var(--color-gray);
+    --plugin-badge-background-color: var(--color-gray-800);
+    --report-background-color: var(--color-gray-900);
+    --report-border-color-secondary: var(--color-gray-200);
+    --report-text-color-secondary: var(--color-gray-400);
+    --report-text-color: var(--color-gray-100);
+    --topbar-background-color: var(--color-gray);
+
+    /* SVGs */
+    --plugin-icon-url: var(--plugin-icon-url-dark);
+    --pwa-fast-reliable-gray-url: var(--pwa-fast-reliable-gray-url-dark);
+    --pwa-installable-gray-url: var(--pwa-installable-gray-url-dark);
+    --pwa-optimized-gray-url: var(--pwa-optimized-gray-url-dark);
+  }
+}
+
+@media only screen and (max-width: 480px) {
+  .lh-vars {
+    --audit-group-margin-bottom: 20px;
+    --category-padding: 24px;
+    --env-name-min-width: 120px;
+    --gauge-circle-size-big: 96px;
+    --gauge-circle-size: 72px;
+    --gauge-label-font-size-big: 22px;
+    --gauge-label-font-size: 14px;
+    --gauge-label-line-height-big: 26px;
+    --gauge-label-line-height: 20px;
+    --gauge-percentage-font-size-big: 34px;
+    --gauge-percentage-font-size: 26px;
+    --gauge-wrapper-width: 112px;
+    --header-padding: 16px 0 16px 0;
+    --image-preview-size: 24px;
+    --plugin-icon-size: 75%;
+    --pwa-icon-margin: 0 7px 0 -3px;
+    --report-font-size: 14px;
+    --report-line-height: 20px;
+    --score-icon-margin-left: 2px;
+    --score-icon-size: 10px;
+    --topbar-height: 28px;
+    --topbar-logo-size: 20px;
+  }
+
+  /* Not enough space to adequately show the relative savings bars. */
+  .lh-sparkline {
+    display: none;
+  }
+}
+
+.lh-vars.lh-devtools {
+  --audit-explanation-line-height: 14px;
+  --audit-group-margin-bottom: 20px;
+  --audit-group-padding-vertical: 12px;
+  --audit-padding-vertical: 4px;
+  --category-header-font-size: 16px;
+  --category-padding: 12px;
+  --default-padding: 12px;
+  --env-name-min-width: 120px;
+  --footer-padding-vertical: 8px;
+  --gauge-circle-size-big: 72px;
+  --gauge-circle-size: 64px;
+  --gauge-label-font-size-big: 22px;
+  --gauge-label-font-size: 14px;
+  --gauge-label-line-height-big: 26px;
+  --gauge-label-line-height: 20px;
+  --gauge-percentage-font-size-big: 34px;
+  --gauge-percentage-font-size: 26px;
+  --gauge-wrapper-width: 97px;
+  --header-line-height: 20px;
+  --header-padding: 16px 0 16px 0;
+  --plugin-icon-size: 75%;
+  --pwa-icon-margin: 0 7px 0 -3px;
+  --report-font-family-monospace: 'Menlo', 'dejavu sans mono', 'Consolas', 'Lucida Console', monospace;
+  --report-font-family: '.SFNSDisplay-Regular', 'Helvetica Neue', 'Lucida Grande', sans-serif;
+  --report-font-size: 12px;
+  --report-line-height: 20px;
+  --score-icon-margin-left: 2px;
+  --score-icon-size: 10px;
+  --section-padding-vertical: 8px;
+}
+
+.lh-devtools.lh-root {
+  height: 100%;
+}
+.lh-devtools.lh-root img {
+  /* Override devtools default 'min-width: 0' so svg without size in a flexbox isn't collapsed. */
+  min-width: auto;
+}
+.lh-devtools .lh-container {
+  overflow-y: scroll;
+  height: calc(100% - var(--topbar-height));
+}
+@media print {
+  .lh-devtools .lh-container {
+    overflow: unset;
+  }
+}
+.lh-devtools .lh-sticky-header {
+  /* This is normally the height of the topbar, but we want it to stick to the top of our scroll container .lh-container` */
+  top: 0;
+}
+
+@keyframes fadeIn {
+  0% { opacity: 0;}
+  100% { opacity: 0.6;}
+}
+
+.lh-root *, .lh-root *::before, .lh-root *::after {
+  box-sizing: border-box;
+  -webkit-font-smoothing: antialiased;
+}
+
+.lh-root {
+  font-family: var(--report-font-family);
+  font-size: var(--report-font-size);
+  margin: 0;
+  line-height: var(--report-line-height);
+  background: var(--report-background-color);
+  scroll-behavior: smooth;
+  color: var(--report-text-color);
+}
+
+.lh-root :focus {
+    outline: -webkit-focus-ring-color auto 3px;
+}
+.lh-root summary:focus {
+    outline: none;
+    box-shadow: 0 0 0 1px hsl(217, 89%, 61%);
+}
+
+.lh-root [hidden] {
+  display: none !important;
+}
+
+.lh-root details > summary {
+  cursor: pointer;
+}
+
+.lh-container {
+  /*
+  Text wrapping in the report is so much FUN!
+  We have a `word-break: break-word;` globally here to prevent a few common scenarios, namely
+  long non-breakable text (usually URLs) found in:
+    1. The footer
+    2. .lh-node (outerHTML)
+    3. .lh-code
+
+  With that sorted, the next challenge is appropriate column sizing and text wrapping inside our
+  .lh-details tables. Even more fun.
+    * We don't want table headers ("Potential Savings (ms)") to wrap or their column values, but
+    we'd be happy for the URL column to wrap if the URLs are particularly long.
+    * We want the narrow columns to remain narrow, providing the most column width for URL
+    * We don't want the table to extend past 100% width.
+    * Long URLs in the URL column can wrap. Util.getURLDisplayName maxes them out at 64 characters,
+      but they do not get any overflow:ellipsis treatment.
+  */
+  word-break: break-word;
+}
+
+.lh-audit-group a,
+.lh-category-header__description a,
+.lh-audit__description a,
+.lh-footer a {
+  color: var(--color-informative);
+}
+
+.lh-audit__description, .lh-audit__stackpack {
+  --inner-audit-padding-right: var(--stackpack-padding-horizontal);
+  padding-left: var(--audit-description-padding-left);
+  padding-right: var(--inner-audit-padding-right);
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+.lh-details {
+  font-size: var(--report-font-size);
+  margin-top: var(--default-padding);
+  margin-bottom: var(--default-padding);
+  margin-left: var(--audit-description-padding-left);
+  /* whatever the .lh-details side margins are */
+  width: 100%;
+}
+
+.lh-details.flex .lh-code {
+  max-width: 70%;
+}
+
+.lh-audit__stackpack {
+  display: flex;
+  align-items: center;
+}
+
+.lh-audit__stackpack__img {
+  max-width: 50px;
+  margin-right: var(--default-padding)
+}
+
+/* Report header */
+
+.report-icon {
+  opacity: 0.7;
+}
+.report-icon:hover {
+  opacity: 1;
+}
+.report-icon[disabled] {
+  opacity: 0.3;
+  pointer-events: none;
+}
+
+.report-icon--print {
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z"/><path fill="none" d="M0 0h24v24H0z"/></svg>');
+}
+.report-icon--copy {
+  background-image: url('data:image/svg+xml;utf8,<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>');
+}
+.report-icon--open {
+  background-image: url('data:image/svg+xml;utf8,<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 4H5c-1.11 0-2 .9-2 2v12c0 1.1.89 2 2 2h4v-2H5V8h14v10h-4v2h4c1.1 0 2-.9 2-2V6c0-1.1-.89-2-2-2zm-7 6l-4 4h3v6h2v-6h3l-4-4z"/></svg>');
+}
+.report-icon--download {
+  background-image: url('data:image/svg+xml;utf8,<svg height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><path d="M19 9h-4V3H9v6H5l7 7 7-7zM5 18v2h14v-2H5z"/><path d="M0 0h24v24H0z" fill="none"/></svg>');
+}
+.report-icon--dark {
+  background-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 100 125"><path d="M50 23.587c-16.27 0-22.799 12.574-22.799 21.417 0 12.917 10.117 22.451 12.436 32.471h20.726c2.32-10.02 12.436-19.554 12.436-32.471 0-8.843-6.528-21.417-22.799-21.417zM39.637 87.161c0 3.001 1.18 4.181 4.181 4.181h.426l.41 1.231C45.278 94.449 46.042 95 48.019 95h3.963c1.978 0 2.74-.551 3.365-2.427l.409-1.231h.427c3.002 0 4.18-1.18 4.18-4.181V80.91H39.637v6.251zM50 18.265c1.26 0 2.072-.814 2.072-2.073v-9.12C52.072 5.813 51.26 5 50 5c-1.259 0-2.072.813-2.072 2.073v9.12c0 1.259.813 2.072 2.072 2.072zM68.313 23.727c.994.774 2.135.634 2.91-.357l5.614-7.187c.776-.992.636-2.135-.356-2.909-.992-.776-2.135-.636-2.91.357l-5.613 7.186c-.778.993-.636 2.135.355 2.91zM91.157 36.373c-.306-1.222-1.291-1.815-2.513-1.51l-8.85 2.207c-1.222.305-1.814 1.29-1.51 2.512.305 1.223 1.291 1.814 2.513 1.51l8.849-2.206c1.223-.305 1.816-1.291 1.511-2.513zM86.757 60.48l-8.331-3.709c-1.15-.512-2.225-.099-2.736 1.052-.512 1.151-.1 2.224 1.051 2.737l8.33 3.707c1.15.514 2.225.101 2.736-1.05.513-1.149.1-2.223-1.05-2.737zM28.779 23.37c.775.992 1.917 1.131 2.909.357.992-.776 1.132-1.917.357-2.91l-5.615-7.186c-.775-.992-1.917-1.132-2.909-.357s-1.131 1.917-.356 2.909l5.614 7.187zM21.715 39.583c.305-1.223-.288-2.208-1.51-2.513l-8.849-2.207c-1.222-.303-2.208.289-2.513 1.511-.303 1.222.288 2.207 1.511 2.512l8.848 2.206c1.222.304 2.208-.287 2.513-1.509zM21.575 56.771l-8.331 3.711c-1.151.511-1.563 1.586-1.05 2.735.511 1.151 1.586 1.563 2.736 1.052l8.331-3.711c1.151-.511 1.563-1.586 1.05-2.735-.512-1.15-1.585-1.562-2.736-1.052z"/></svg>');
+}
+
+/* Node */
+.lh-node__snippet {
+  font-family: var(--report-font-family-monospace);
+  color: var(--color-teal-600);
+  font-size: 12px;
+  line-height: 1.5em;
+}
+
+/* Score */
+
+.lh-audit__score-icon {
+  width: var(--score-icon-size);
+  height: var(--score-icon-size);
+  margin: var(--score-icon-margin);
+}
+
+.lh-audit--pass .lh-audit__display-text {
+  color: var(--color-pass-secondary);
+}
+.lh-audit--pass .lh-audit__score-icon {
+  border-radius: 100%;
+  background: var(--color-pass);
+}
+
+.lh-audit--average .lh-audit__display-text {
+  color: var(--color-average-secondary);
+}
+.lh-audit--average .lh-audit__score-icon {
+  background: var(--color-average);
+  width: var(--icon-square-size);
+  height: var(--icon-square-size);
+}
+
+.lh-audit--fail .lh-audit__display-text {
+  color: var(--color-fail-secondary);
+}
+.lh-audit--fail .lh-audit__score-icon,
+.lh-audit--error .lh-audit__score-icon {
+  border-left: calc(var(--score-icon-size) / 2) solid transparent;
+  border-right: calc(var(--score-icon-size) / 2) solid transparent;
+  border-bottom: var(--score-icon-size) solid var(--color-fail);
+}
+
+.lh-audit--manual .lh-audit__display-text,
+.lh-audit--notapplicable .lh-audit__display-text {
+  color: var(--color-gray-600);
+}
+.lh-audit--manual .lh-audit__score-icon,
+.lh-audit--notapplicable .lh-audit__score-icon {
+  border-radius: 100%;
+  background: var(--color-gray-400);
+}
+
+.lh-audit--informative .lh-audit__display-text {
+  color: var(--color-gray-600);
+}
+
+.lh-audit--informative .lh-audit__score-icon {
+  border: none;
+  border-radius: 100%;
+  background: var(--color-gray-400);
+}
+
+.lh-audit__description,
+.lh-audit__stackpack {
+  color: var(--report-text-color-secondary);
+}
+.lh-category-header__description  {
+  font-size: var(--report-font-size);
+  text-align: center;
+  margin: 0px auto;
+  max-width: 400px;
+}
+
+
+.lh-audit__display-text,
+.lh-load-opportunity__sparkline,
+.lh-chevron-container {
+  margin: 0 var(--audit-margin-horizontal);
+}
+.lh-chevron-container {
+  margin-right: 0;
+}
+
+.lh-audit__title-and-text {
+  flex: 1;
+}
+
+/* Prepend display text with em dash separator. But not in Opportunities. */
+.lh-audit__display-text:not(:empty):before {
+  content: '—';
+  margin-right: var(--audit-margin-horizontal);
+}
+.lh-audit-group.lh-audit-group--load-opportunities .lh-audit__display-text:not(:empty):before {
+  display: none;
+}
+
+/* Expandable Details (Audit Groups, Audits) */
+.lh-audit__header {
+  display: flex;
+  align-items: center;
+  font-weight: 500;
+  padding: var(--audit-padding-vertical) 0;
+}
+
+.lh-audit--load-opportunity .lh-audit__header {
+  display: block;
+}
+
+.lh-audit__header:hover {
+  background-color: var(--color-hover);
+}
+
+/* Hide the expandable arrow icon, three ways: via the CSS Counter Styles spec, for webkit/blink browsers, hiding the polyfilled icon */
+/* https://github.com/javan/details-element-polyfill/blob/master/src/details-element-polyfill/polyfill.sass */
+.lh-audit-group > summary,
+.lh-expandable-details > summary {
+  list-style-type: none;
+}
+.lh-audit-group > summary::-webkit-details-marker,
+.lh-expandable-details > summary::-webkit-details-marker {
+  display: none;
+}
+.lh-audit-group > summary:before,
+.lh-expandable-details > summary:before {
+  display: none;
+}
+
+
+/* Perf Metric */
+
+.lh-columns {
+  display: flex;
+  width: 100%;
+}
+@media screen and (max-width: 640px) {
+  .lh-columns {
+    flex-wrap: wrap;
+
+  }
+}
+
+.lh-column {
+  flex: 1;
+}
+.lh-column:first-of-type {
+  margin-right: 24px;
+}
+
+@media screen and (max-width: 800px) {
+  .lh-column:first-of-type {
+    margin-right: 8px;
+  }
+}
+@media screen and (max-width: 640px) {
+  .lh-column {
+    flex-basis: 100%;
+  }
+  .lh-column:first-of-type {
+    margin-right: 0px;
+  }
+  .lh-column:first-of-type .lh-metric:last-of-type {
+    border-bottom: 0;
+  }
+}
+
+
+.lh-metric {
+  border-bottom: 1px solid var(--report-border-color-secondary);
+}
+.lh-metric:first-of-type {
+  border-top: 1px solid var(--report-border-color-secondary);
+}
+
+.lh-metric__innerwrap {
+  display: grid;
+  grid-template-columns: var(--audit-description-padding-left) 10fr 3fr;
+  align-items: center;
+  padding: 10px 0;
+}
+
+.lh-metric__details {
+  order: -1;
+}
+
+.lh-metric__title {
+  flex: 1;
+  font-weight: 500;
+}
+
+.lh-metrics__disclaimer {
+  color: var(--color-gray-600);
+  margin: var(--section-padding-vertical) 0;
+}
+.lh-metrics__disclaimer a {
+  color: var(--color-gray-700);
+}
+
+.lh-metric__description {
+  display: none;
+  grid-column-start: 2;
+  grid-column-end: 3;
+  color: var(--report-text-color-secondary);
+}
+
+.lh-metric__value {
+  white-space: nowrap; /* No wrapping between metric value and the icon */
+  font-weight: 500;
+  justify-self: end;
+}
+
+/* No-JS toggle switch */
+/* Keep this selector sync'd w/ `magicSelector` in report-ui-features-test.js */
+ .lh-metrics-toggle__input:checked ~ .lh-columns .lh-metric__description {
+  display: block;
+}
+
+.lh-metrics-toggle__input {
+  cursor: pointer;
+  opacity: 0;
+  position: absolute;
+  right: 0;
+  width: 74px;
+  height: 28px;
+  top: -3px;
+}
+.lh-metrics-toggle__label {
+  display: flex;
+  background-color: #eee;
+  border-radius: 20px;
+  overflow: hidden;
+  position: absolute;
+  right: 0;
+  top: -3px;
+  pointer-events: none;
+}
+.lh-metrics-toggle__input:focus + label {
+  outline: -webkit-focus-ring-color auto 3px;
+}
+.lh-metrics-toggle__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 5px;
+  width: 50%;
+  height: 28px;
+}
+.lh-metrics-toggle__input:not(:checked) + label .lh-metrics-toggle__icon--less,
+.lh-metrics-toggle__input:checked + label .lh-metrics-toggle__icon--more {
+  background-color: var(--color-blue-A700);
+  --metric-toggle-lines-fill: var(--color-white);
+}
+.lh-metrics-toggle__lines {
+  fill: var(--metric-toggle-lines-fill);
+}
+
+.lh-metrics-toggle__label  {
+  background-color: var(--metrics-toggle-background-color);
+}
+
+.lh-metrics-toggle__label .lh-metrics-toggle__icon--less {
+  padding-left: 8px;
+}
+.lh-metrics-toggle__label .lh-metrics-toggle__icon--more {
+  padding-right: 8px;
+}
+
+/* Pushes the metric description toggle button to the right. */
+.lh-audit-group--metrics .lh-audit-group__header {
+  display: flex;
+}
+.lh-audit-group--metrics .lh-audit-group__header span.lh-audit-group__title {
+  flex: 1;
+}
+
+.lh-metric .lh-metric__innerwrap::before {
+  content: '';
+  width: var(--score-icon-size);
+  height: var(--score-icon-size);
+  display: inline-block;
+  margin: var(--score-icon-margin);
+}
+
+.lh-metric--pass .lh-metric__value {
+  color: var(--color-pass-secondary);
+}
+.lh-metric--pass .lh-metric__innerwrap::before {
+  border-radius: 100%;
+  background: var(--color-pass);
+}
+
+.lh-metric--average .lh-metric__value {
+  color: var(--color-average-secondary);
+}
+.lh-metric--average .lh-metric__innerwrap::before {
+  background: var(--color-average);
+  width: var(--icon-square-size);
+  height: var(--icon-square-size);
+}
+
+.lh-metric--fail .lh-metric__value {
+  color: var(--color-fail-secondary);
+}
+.lh-metric--fail .lh-metric__innerwrap::before,
+.lh-metric--error .lh-metric__innerwrap::before {
+  border-left: calc(var(--score-icon-size) / 2) solid transparent;
+  border-right: calc(var(--score-icon-size) / 2) solid transparent;
+  border-bottom: var(--score-icon-size) solid var(--color-fail);
+}
+
+.lh-metric--error .lh-metric__value,
+.lh-metric--error .lh-metric__description {
+  color: var(--color-fail-secondary);
+}
+
+/* Perf load opportunity */
+
+.lh-load-opportunity__cols {
+  display: flex;
+  align-items: flex-start;
+}
+
+.lh-load-opportunity__header .lh-load-opportunity__col {
+  color: var(--color-gray-600);
+  display: unset;
+  line-height: calc(2.3 * var(--report-font-size));
+}
+
+.lh-load-opportunity__col {
+  display: flex;
+}
+
+.lh-load-opportunity__col--one {
+  flex: 5;
+  align-items: center;
+  margin-right: 2px;
+}
+.lh-load-opportunity__col--two {
+  flex: 4;
+  text-align: right;
+}
+
+.lh-audit--load-opportunity .lh-audit__display-text {
+  text-align: right;
+  flex: 0 0 calc(3 * var(--report-font-size));
+}
+
+
+/* Sparkline */
+
+.lh-load-opportunity__sparkline {
+  flex: 1;
+  margin-top: calc((var(--report-line-height) - var(--sparkline-height)) / 2);
+}
+
+.lh-sparkline {
+  height: var(--sparkline-height);
+  width: 100%;
+}
+
+.lh-sparkline__bar {
+  height: 100%;
+  float: right;
+}
+
+.lh-audit--pass .lh-sparkline__bar {
+  background: var(--color-pass);
+}
+
+.lh-audit--average .lh-sparkline__bar {
+  background: var(--color-average);
+}
+
+.lh-audit--fail .lh-sparkline__bar {
+  background: var(--color-fail);
+}
+
+
+
+/* Filmstrip */
+
+.lh-filmstrip-container {
+  /* smaller gap between metrics and filmstrip */
+  margin: -8px auto 0 auto;
+}
+
+.lh-filmstrip {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding-bottom: var(--default-padding);
+}
+
+.lh-filmstrip__frame {
+  text-align: right;
+  position: relative;
+}
+
+.lh-filmstrip__thumbnail {
+  border: 1px solid var(--report-border-color-secondary);
+  max-height: 100px;
+  max-width: 60px;
+}
+
+@media screen and (max-width: 750px) {
+  .lh-filmstrip {
+    flex-wrap: wrap;
+  }
+  .lh-filmstrip__frame {
+    width: 20%;
+    margin-bottom: 5px;
+  }
+  .lh-filmstrip__thumbnail {
+    display: block;
+    margin: auto;
+  }
+}
+
+/* Audit */
+
+.lh-audit {
+  border-bottom: 1px solid var(--report-border-color-secondary);
+}
+
+/* Apply border-top to just the first audit. */
+.lh-audit {
+  border-top: 1px solid var(--report-border-color-secondary);
+}
+.lh-audit ~ .lh-audit {
+  border-top: none;
+}
+
+
+.lh-audit--error .lh-audit__display-text {
+  color: var(--color-fail);
+}
+
+/* Audit Group */
+
+.lh-audit-group {
+  margin-bottom: var(--audit-group-margin-bottom);
+  position: relative;
+}
+
+.lh-audit-group__header::before {
+  /* By default, groups don't get an icon */
+  content: none;
+  width: var(--pwa-icon-size);
+  height: var(--pwa-icon-size);
+  margin: var(--pwa-icon-margin);
+  display: inline-block;
+  vertical-align: middle;
+}
+
+/* Style the "over budget" columns red. */
+.lh-audit-group--budgets .lh-table tbody tr td:nth-child(4),
+.lh-audit-group--budgets .lh-table tbody tr td:nth-child(5){
+  color: var(--color-red-700);
+}
+
+/* Align the "over budget request count" text to be close to the "over budget bytes" column. */
+.lh-audit-group--budgets .lh-table tbody tr td:nth-child(4){
+  text-align: right;
+}
+
+.lh-audit-group--budgets .lh-table {
+  width: 100%;
+}
+
+.lh-audit-group--pwa-fast-reliable .lh-audit-group__header::before {
+  content: '';
+  background-image: var(--pwa-fast-reliable-gray-url);
+}
+.lh-audit-group--pwa-installable .lh-audit-group__header::before {
+  content: '';
+  background-image: var(--pwa-installable-gray-url);
+}
+.lh-audit-group--pwa-optimized .lh-audit-group__header::before {
+  content: '';
+  background-image: var(--pwa-optimized-gray-url);
+}
+.lh-audit-group--pwa-fast-reliable.lh-badged .lh-audit-group__header::before {
+  background-image: var(--pwa-fast-reliable-color-url);
+}
+.lh-audit-group--pwa-installable.lh-badged .lh-audit-group__header::before {
+  background-image: var(--pwa-installable-color-url);
+}
+.lh-audit-group--pwa-optimized.lh-badged .lh-audit-group__header::before {
+  background-image: var(--pwa-optimized-color-url);
+}
+
+.lh-audit-group--metrics .lh-audit-group__summary {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.lh-audit-group__summary {
+  display: flex;
+  justify-content: space-between;
+  margin-top: calc(var(--category-padding) * 1.5);
+  margin-bottom: var(--category-padding);
+}
+
+.lh-audit-group__itemcount {
+  color: var(--color-gray-600);
+  font-weight: bold;
+}
+.lh-audit-group__header .lh-chevron {
+  margin-top: calc((var(--report-line-height) - 5px) / 2);
+}
+
+.lh-audit-group__header {
+  font-size: var(--report-font-size);
+  margin: 0 0 var(--audit-group-padding-vertical);
+  /* When the header takes 100% width, the chevron becomes small. */
+  max-width: calc(100% - var(--chevron-size));
+}
+/* max-width makes the metric toggle not flush. metrics doesn't have a chevron so unset. */
+.lh-audit-group--metrics .lh-audit-group__header {
+  max-width: unset;
+}
+
+.lh-audit-group__header span.lh-audit-group__title {
+  font-weight: bold;
+}
+
+.lh-audit-group__header span.lh-audit-group__itemcount {
+  font-weight: bold;
+  color: var(--color-gray-600);
+}
+
+.lh-audit-group__header span.lh-audit-group__description {
+  font-weight: 500;
+  color: var(--color-gray-600);
+}
+.lh-audit-group__header span.lh-audit-group__description::before {
+  content: '—';
+  margin: 0px var(--audit-margin-horizontal);
+}
+
+.lh-clump > .lh-audit-group__header,
+.lh-audit-group--diagnostics .lh-audit-group__header,
+.lh-audit-group--load-opportunities .lh-audit-group__header,
+.lh-audit-group--metrics .lh-audit-group__header,
+.lh-audit-group--pwa-fast-reliable .lh-audit-group__header,
+.lh-audit-group--pwa-installable .lh-audit-group__header,
+.lh-audit-group--pwa-optimized .lh-audit-group__header {
+  margin-top: var(--audit-group-padding-vertical);
+}
+
+.lh-audit-explanation {
+  margin: var(--audit-padding-vertical) 0 calc(var(--audit-padding-vertical) / 2) var(--audit-margin-horizontal);
+  line-height: var(--audit-explanation-line-height);
+  display: inline-block;
+}
+
+.lh-audit--fail .lh-audit-explanation {
+  color: var(--color-fail);
+}
+
+/* Report */
+.lh-list > div:not(:last-child) {
+  padding-bottom: 20px;
+}
+
+.lh-header-container {
+  display: block;
+  margin: 0 auto;
+  position: relative;
+  word-wrap: break-word;
+}
+
+.lh-report {
+  min-width: var(--report-min-width);
+}
+
+.lh-exception {
+  font-size: large;
+}
+
+.lh-code {
+  white-space: normal;
+  margin-top: 0;
+  font-size: 85%;
+}
+
+.lh-warnings {
+  --item-margin: calc(var(--report-line-height) / 6);
+  color: var(--color-average);
+  margin: var(--audit-padding-vertical) 0;
+  padding: calc(var(--audit-padding-vertical) / 2) var(--audit-padding-vertical);
+}
+.lh-warnings span {
+  font-weight: bold;
+}
+
+.lh-warnings--toplevel {
+  --item-margin: calc(var(--header-line-height) / 4);
+  color: var(--report-text-color-secondary);
+  margin-left: auto;
+  margin-right: auto;
+  max-width: calc(var(--report-width) - var(--category-padding) * 2);
+  background-color: var(--color-amber-50);
+  padding: var(--toplevel-warning-padding);
+}
+
+.lh-warnings ul {
+  padding-left: calc(var(--category-padding) * 2);
+  margin: 0;
+}
+.lh-warnings li {
+  margin: var(--item-margin) 0;
+}
+.lh-warnings li:last-of-type {
+  margin-bottom: 0;
+}
+
+.lh-scores-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.lh-scores-header__solo {
+  padding: 0;
+  border: 0;
+}
+
+/* Gauge */
+
+.lh-gauge__wrapper--pass {
+  color: var(--color-pass);
+  fill: var(--color-pass);
+  stroke: var(--color-pass);
+}
+
+.lh-gauge__wrapper--average {
+  color: var(--color-average);
+  fill: var(--color-average);
+  stroke: var(--color-average);
+}
+
+.lh-gauge__wrapper--fail {
+  color: var(--color-fail);
+  fill: var(--color-fail);
+  stroke: var(--color-fail);
+}
+
+.lh-gauge {
+  stroke-linecap: round;
+  width: var(--gauge-circle-size);
+  height: var(--gauge-circle-size);
+}
+
+.lh-category .lh-gauge {
+  --gauge-circle-size: var(--gauge-circle-size-big);
+}
+
+.lh-gauge-base {
+    opacity: 0.1;
+    stroke: var(--circle-background);
+    stroke-width: var(--circle-border-width);
+}
+
+.lh-gauge-arc {
+    fill: none;
+    stroke: var(--circle-color);
+    stroke-width: var(--circle-border-width);
+    animation: load-gauge var(--transition-length) ease forwards;
+    animation-delay: 250ms;
+}
+
+.lh-gauge__svg-wrapper {
+  position: relative;
+  height: var(--gauge-circle-size);
+}
+.lh-category .lh-gauge__svg-wrapper {
+  --gauge-circle-size: var(--gauge-circle-size-big);
+}
+
+/* The plugin badge overlay */
+.lh-gauge__wrapper--plugin .lh-gauge__svg-wrapper::before {
+  width: var(--plugin-badge-size);
+  height: var(--plugin-badge-size);
+  background-color: var(--plugin-badge-background-color);
+  background-image: var(--plugin-icon-url);
+  background-repeat: no-repeat;
+  background-size: var(--plugin-icon-size);
+  background-position: 58% 50%;
+  content: "";
+  position: absolute;
+  right: -6px;
+  bottom: 0px;
+  display: block;
+  z-index: 100;
+  box-shadow: 0 0 4px rgba(0,0,0,.2);
+  border-radius: 25%;
+}
+.lh-category .lh-gauge__wrapper--plugin .lh-gauge__svg-wrapper::before {
+  width: var(--plugin-badge-size-big);
+  height: var(--plugin-badge-size-big);
+}
+
+@keyframes load-gauge {
+  from { stroke-dasharray: 0 352; }
+}
+
+.lh-gauge__percentage {
+  width: 100%;
+  height: var(--gauge-circle-size);
+  position: absolute;
+  font-family: var(--report-font-family-monospace);
+  font-size: calc(var(--gauge-circle-size) * 0.34 + 1.3px);
+  line-height: 0;
+  text-align: center;
+  top: calc(var(--score-container-padding) + var(--gauge-circle-size) / 2);
+}
+
+.lh-category .lh-gauge__percentage {
+  --gauge-circle-size: var(--gauge-circle-size-big);
+  --gauge-percentage-font-size: var(--gauge-percentage-font-size-big);
+}
+
+.lh-gauge__wrapper {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  text-decoration: none;
+  padding: var(--score-container-padding);
+
+  --circle-border-width: 8;
+  --transition-length: 1s;
+
+  /* Contain the layout style paint & layers during animation*/
+  contain: content;
+  will-change: opacity; /* Only using for layer promotion */
+}
+
+.lh-gauge__label {
+  font-size: var(--gauge-label-font-size);
+  line-height: var(--gauge-label-line-height);
+  margin-top: 10px;
+  text-align: center;
+  color: var(--report-text-color);
+}
+
+/* TODO(#8185) use more BEM (.lh-gauge__label--big) instead of relying on descendant selector */
+.lh-category .lh-gauge__label {
+  --gauge-label-font-size: var(--gauge-label-font-size-big);
+  --gauge-label-line-height: var(--gauge-label-line-height-big);
+  margin-top: 14px;
+}
+
+
+.lh-scores-header .lh-gauge__wrapper,
+.lh-scores-header .lh-gauge--pwa__wrapper,
+.lh-sticky-header .lh-gauge__wrapper,
+.lh-sticky-header .lh-gauge--pwa__wrapper {
+  width: var(--gauge-wrapper-width);
+}
+
+.lh-scorescale {
+  display: inline-flex;
+  margin: 12px auto 0 auto;
+  border: 1px solid var(--color-gray-200);
+  border-radius: 20px;
+  padding: 8px 8px;
+}
+
+.lh-scorescale-range {
+  display: flex;
+  align-items: center;
+  margin: 0 12px;
+  font-family: var(--report-font-family-monospace);
+  white-space: nowrap;
+}
+
+.lh-scorescale-range::before {
+  content: '';
+  width: var(--scorescale-width);
+  height: var(--scorescale-height);
+  border-radius: 10px;
+  display: block;
+  margin-right: 10px;
+}
+
+.lh-scorescale-range--pass::before {
+  background-color: var(--color-pass);
+}
+
+.lh-scorescale-range--average::before {
+  background-color: var(--color-average);
+}
+
+.lh-scorescale-range--fail::before {
+  background-color: var(--color-fail);
+}
+
+/* Hide category score gauages if it's a single category report */
+.lh-header--solo-category .lh-scores-wrapper {
+  display: none;
+}
+
+
+.lh-categories {
+  width: 100%;
+  overflow: hidden;
+}
+
+.lh-category {
+  padding: var(--category-padding);
+  max-width: var(--report-width);
+  margin: 0 auto;
+}
+
+.lh-category-wrapper {
+  border-bottom: 1px solid var(--color-gray-200);
+}
+
+.lh-category-wrapper:first-of-type {
+  border-top: 1px solid var(--color-gray-200);
+}
+
+/* section hash link jump should preserve fixed header
+   https://css-tricks.com/hash-tag-links-padding/
+*/
+.lh-category > .lh-permalink {
+  --sticky-header-height: calc(var(--gauge-circle-size) + var(--score-container-padding) * 2);
+  --topbar-plus-header: calc(var(--topbar-height) + var(--sticky-header-height));
+  margin-top: calc(var(--topbar-plus-header) * -1);
+  padding-bottom: var(--topbar-plus-header);
+  display: block;
+  visibility: hidden;
+}
+
+.lh-category-header {
+  font-size: var(--category-header-font-size);
+  min-height: var(--gauge-circle-size);
+  margin-bottom: var(--section-padding-vertical);
+}
+
+.lh-category-header .lh-score__gauge {
+  max-width: 400px;
+  width: auto;
+  margin: 0px auto;
+}
+
+.lh-category-header .lh-audit__title {
+  font-size: var(--category-header-font-size);
+  line-height: var(--header-line-height);
+}
+
+#lh-log {
+  position: fixed;
+  background-color: #323232;
+  color: #fff;
+  min-height: 48px;
+  min-width: 288px;
+  padding: 16px 24px;
+  box-shadow: 0 2px 5px 0 rgba(0, 0, 0, 0.26);
+  border-radius: 2px;
+  margin: 12px;
+  font-size: 14px;
+  cursor: default;
+  transition: transform 0.3s, opacity 0.3s;
+  transform: translateY(100px);
+  opacity: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 3;
+}
+
+#lh-log.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* 964 fits the min-width of the filmstrip */
+@media screen and (max-width: 964px) {
+  .lh-report {
+    margin-left: 0;
+    width: 100%;
+  }
+}
+
+@media print {
+  body {
+    -webkit-print-color-adjust: exact; /* print background colors */
+  }
+  .lh-container {
+    display: block;
+  }
+  .lh-report {
+    margin-left: 0;
+    padding-top: 0;
+  }
+  .lh-categories {
+    margin-top: 0;
+  }
+}
+
+.lh-table {
+  border-collapse: collapse;
+  /* Can't assign padding to table, so shorten the width instead. */
+  width: calc(100% - var(--audit-description-padding-left));
+}
+
+.lh-table thead th {
+  font-weight: normal;
+  color: var(--color-gray-600);
+  /* See text-wrapping comment on .lh-container. */
+  word-break: normal;
+}
+
+.lh-table tbody tr:nth-child(odd) {
+  background-color: var(--table-higlight-background-color);
+}
+
+.lh-table th,
+.lh-table td {
+  padding: 8px 6px;
+}
+.lh-table th:first-child {
+  padding-left: 0;
+}
+.lh-table th:last-child {
+  padding-right: 0;
+}
+
+/* Looks unnecessary, but mostly for keeping the <th>s left-aligned */
+.lh-table-column--text,
+.lh-table-column--url,
+/* .lh-table-column--thumbnail, */
+/* .lh-table-column--empty,*/
+.lh-table-column--code,
+.lh-table-column--node {
+  text-align: left;
+}
+
+.lh-table-column--bytes,
+.lh-table-column--timespanMs,
+.lh-table-column--ms,
+.lh-table-column--numeric {
+  text-align: right;
+  word-break: normal;
+}
+
+
+
+.lh-table .lh-table-column--thumbnail {
+  width: var(--image-preview-size);
+  padding: 0;
+}
+
+.lh-table-column--url {
+  min-width: 250px;
+}
+
+/* Keep columns narrow if they follow the URL column */
+/* 12% was determined to be a decent narrow width, but wide enough for column headings */
+.lh-table-column--url + th.lh-table-column--bytes,
+.lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--bytes,
+.lh-table-column--url + .lh-table-column--ms,
+.lh-table-column--url + .lh-table-column--ms + th.lh-table-column--bytes,
+.lh-table-column--url + .lh-table-column--bytes + th.lh-table-column--timespanMs {
+  width: 12%;
+}
+
+
+.lh-text__url-host {
+  display: inline;
+}
+
+.lh-text__url-host {
+  margin-left: calc(var(--report-font-size) / 2);
+  opacity: 0.6;
+  font-size: 90%
+}
+
+.lh-thumbnail {
+  object-fit: cover;
+  width: var(--image-preview-size);
+  height: var(--image-preview-size);
+  display: block;
+}
+
+.lh-unknown pre {
+  overflow: scroll;
+  border: solid 1px var(--color-gray-200);
+}
+
+.lh-text__url > a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.lh-text__url > a:hover {
+  text-decoration: underline dotted #999;
+}
+
+/* Chevron
+   https://codepen.io/paulirish/pen/LmzEmK
+ */
+.lh-chevron {
+  --chevron-angle: 42deg;
+  /* Edge doesn't support transform: rotate(calc(...)), so we define it here */
+  --chevron-angle-right: -42deg;
+  width: var(--chevron-size);
+  height: var(--chevron-size);
+  margin-top: calc((var(--report-line-height) - 12px) / 2);
+}
+
+.lh-chevron__lines {
+  transition: transform 0.4s;
+  transform: translateY(var(--report-line-height));
+}
+.lh-chevron__line {
+ stroke: var(--chevron-line-stroke);
+ stroke-width: var(--chevron-size);
+ stroke-linecap: square;
+ transform-origin: 50%;
+ transform: rotate(var(--chevron-angle));
+ transition: transform 300ms, stroke 300ms;
+}
+
+.lh-audit-group > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-right,
+.lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-left,
+.lh-audit > .lh-expandable-details .lh-chevron__line-right,
+.lh-audit > .lh-expandable-details[open] .lh-chevron__line-left {
+ transform: rotate(var(--chevron-angle-right));
+}
+
+.lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__line-right,
+.lh-audit > .lh-expandable-details[open] .lh-chevron__line-right {
+  transform: rotate(var(--chevron-angle));
+}
+
+.lh-audit-group[open] > summary > .lh-audit-group__summary > .lh-chevron .lh-chevron__lines,
+.lh-audit > .lh-expandable-details[open] .lh-chevron__lines {
+ transform: translateY(calc(var(--chevron-size) * -1));
+}
+
+
+
+/* Tooltip */
+.tooltip-boundary {
+  position: relative;
+}
+
+.tooltip {
+  position: absolute;
+  display: none; /* Don't retain these layers when not needed */
+  opacity: 0;
+  background: #ffffff;
+  min-width: 246px;
+  max-width: 275px;
+  padding: 15px;
+  border-radius: 5px;
+  text-align: initial;
+}
+/* shrink tooltips to not be cutoff on left edge of narrow viewports
+   45vw is chosen to be ~= width of the left column of metrics
+*/
+@media screen and (max-width: 535px) {
+  .tooltip {
+    min-width: 45vw;
+    padding: 3vw;
+  }
+}
+
+.tooltip-boundary:hover {
+  background-color: var(--color-hover);
+}
+
+.tooltip-boundary:hover .tooltip {
+  display: block;
+  animation: fadeInTooltip 250ms;
+  animation-fill-mode: forwards;
+  animation-delay: 850ms;
+  bottom: 100%;
+  z-index: 1;
+  will-change: opacity;
+  right: 0;
+  pointer-events: none;
+}
+
+.tooltip::before {
+  content: "";
+  border: solid transparent;
+  border-bottom-color: #fff;
+  border-width: 10px;
+  position: absolute;
+  bottom: -20px;
+  right: 6px;
+  transform: rotate(180deg);
+  pointer-events: none;
+}
+
+@keyframes fadeInTooltip {
+  0% { opacity: 0; }
+  75% { opacity: 1; }
+  100% { opacity: 1;  filter: drop-shadow(1px 0px 1px #aaa) drop-shadow(0px 2px 4px hsla(206, 6%, 25%, 0.15)); pointer-events: auto; }
+}
+</style>
+</head>
+<body class="lh-root lh-vars">
+  <noscript>Lighthouse report requires JavaScript. Please enable.</noscript>
+  <div hidden><!--
+@license
+Copyright 2018 Google Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<!-- Lighthouse run warnings -->
+<template id="tmpl-lh-warnings--toplevel">
+  <div class="lh-warnings lh-warnings--toplevel">
+    <strong class="lh-warnings__msg"></strong>
+    <ul></ul>
+  </div>
+</template>
+
+<!-- Lighthouse score scale -->
+<template id="tmpl-lh-scorescale">
+  <div class="lh-scorescale">
+      <span class="lh-scorescale-range lh-scorescale-range--fail">0&ndash;49</span>
+      <span class="lh-scorescale-range lh-scorescale-range--average">50&ndash;89</span>
+      <span class="lh-scorescale-range lh-scorescale-range--pass">90&ndash;100</span>
+  </div>
+</template>
+
+<!-- Toggle arrow chevron -->
+<template id="tmpl-lh-chevron">
+  <svg class="lh-chevron" title="See audits" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 100 100">
+    <g class="lh-chevron__lines">
+      <path class="lh-chevron__line lh-chevron__line-left" d="M10 50h40"></path>
+      <path class="lh-chevron__line lh-chevron__line-right" d="M90 50H50"></path>
+    </g>
+  </svg>
+</template>
+
+<!-- Lighthouse category header -->
+<template id="tmpl-lh-category-header">
+  <div class="lh-category-header">
+    <div class="lh-score__gauge" role="heading" aria-level="2"></div>
+    <div class="lh-category-header__description"></div>
+  </div>
+</template>
+
+<!-- Lighthouse clump -->
+<template id="tmpl-lh-clump">
+  <!-- TODO: group classes shouldn't be reused for clumps. -->
+  <details class="lh-clump lh-audit-group">
+    <summary>
+      <div class="lh-audit-group__summary">
+        <div class="lh-audit-group__header">
+          <span class="lh-audit-group__title"></span>
+          <span class="lh-audit-group__itemcount"></span>
+          <!-- .lh-audit-group__description will be added here -->
+          <!-- .lh-metrics-toggle will be added here -->
+        </div>
+        <div class=""></div>
+      </div>
+    </summary>
+  </details>
+</template>
+
+<!-- Lighthouse metrics toggle -->
+<template id="tmpl-lh-metrics-toggle">
+  <div class="lh-metrics-toggle">
+    <input class="lh-metrics-toggle__input" type="checkbox" id="toggle-metric-descriptions" aria-label="Toggle the display of metric descriptions">
+    <label class="lh-metrics-toggle__label" for="toggle-metric-descriptions">
+      <div class="lh-metrics-toggle__icon lh-metrics-toggle__icon--less" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="24" height="24" viewBox="0 0 24 24">
+          <path class="lh-metrics-toggle__lines" d="M4 9h16v2H4zm0 4h10v2H4z" />
+        </svg>
+      </div>
+      <div class="lh-metrics-toggle__icon lh-metrics-toggle__icon--more" aria-hidden="true">
+        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+          <path class="lh-metrics-toggle__lines" d="M3 18h12v-2H3v2zM3 6v2h18V6H3zm0 7h18v-2H3v2z" />
+        </svg>
+      </div>
+    </label>
+  </div>
+</template>
+
+<!-- Lighthouse audit -->
+<template id="tmpl-lh-audit">
+  <div class="lh-audit">
+    <details class="lh-expandable-details">
+      <summary>
+        <div class="lh-audit__header lh-expandable-details__summary">
+          <span class="lh-audit__score-icon"></span>
+          <span class="lh-audit__title-and-text">
+            <span class="lh-audit__title"></span>
+            <span class="lh-audit__display-text"></span>
+          </span>
+          <div class="lh-chevron-container"></div>
+        </div>
+      </summary>
+      <div class="lh-audit__description"></div>
+      <div class="lh-audit__stackpacks"></div>
+    </details>
+  </div>
+</template>
+
+<!-- Lighthouse perf metric -->
+<template id="tmpl-lh-metric">
+  <div class="lh-metric">
+    <div class="lh-metric__innerwrap">
+      <span class="lh-metric__title"></span>
+      <div class="lh-metric__value"></div>
+      <div class="lh-metric__description"></div>
+    </div>
+  </div>
+</template>
+
+<!-- Lighthouse perf opportunity -->
+<template id="tmpl-lh-opportunity">
+  <div class="lh-audit lh-audit--load-opportunity">
+    <details class="lh-expandable-details">
+        <summary>
+          <div class="lh-audit__header lh-expandable-details__summary">
+            <div class="lh-load-opportunity__cols">
+              <div class="lh-load-opportunity__col lh-load-opportunity__col--one">
+                <span class="lh-audit__score-icon"></span>
+                <div class="lh-audit__title"></div>
+              </div>
+              <div class="lh-load-opportunity__col lh-load-opportunity__col--two">
+                <div class="lh-load-opportunity__sparkline">
+                  <div class="lh-sparkline"><div class="lh-sparkline__bar"></div></div>
+                </div>
+                <div class="lh-audit__display-text"></div>
+                <div class="lh-chevron-container" title="See resources"></div>
+              </div>
+            </div>
+          </div>
+        </summary>
+      <div class="lh-audit__description"></div>
+      <div class="lh-audit__stackpacks"></div>
+    </details>
+  </div>
+</template>
+
+<!-- Lighthouse perf opportunity header -->
+<template id="tmpl-lh-opportunity-header">
+  <div class="lh-load-opportunity__header lh-load-opportunity__cols">
+    <div class="lh-load-opportunity__col lh-load-opportunity__col--one"></div>
+    <div class="lh-load-opportunity__col lh-load-opportunity__col--two"></div>
+  </div>
+</template>
+
+<!-- Lighthouse score container -->
+<template id="tmpl-lh-scores-wrapper">
+  <style>
+    .lh-scores-container {
+      display: flex;
+      flex-direction: column;
+      padding: var(--scores-container-padding);
+      position: relative;
+      width: 100%;
+    }
+
+    .lh-sticky-header {
+      --gauge-circle-size: 36px;
+      --plugin-badge-size: 18px;
+      --plugin-icon-size: 75%;
+      --gauge-wrapper-width: 60px;
+      --gauge-percentage-font-size: 13px;
+      position: sticky;
+      left: 0;
+      right: 0;
+      top: var(--topbar-height);
+      font-weight: 700;
+      display: none;
+      justify-content: center;
+      background-color: var(--sticky-header-background-color);
+      border-bottom: 1px solid var(--color-gray-200);
+      padding-top: var(--score-container-padding);
+      padding-bottom: 4px;
+      z-index: 1;
+      pointer-events: none;
+    }
+
+    .lh-sticky-header--visible {
+      display: grid;
+      grid-auto-flow: column;
+      pointer-events: auto;
+    }
+
+    /* Disable the gauge arc animation for the sticky header, so toggling display: none
+       does not play the animation. */
+    .lh-sticky-header .lh-gauge-arc {
+      animation: none;
+    }
+
+    .lh-sticky-header .lh-gauge__label {
+      display: none;
+    }
+
+    .lh-highlighter {
+      width: var(--gauge-wrapper-width);
+      height: 1px;
+      background-color: var(--highlighter-background-color);
+      /* Position at bottom of first gauge in sticky header. */
+      position: absolute;
+      grid-column: 1;
+      bottom: -1px;
+    }
+
+    .lh-gauge__wrapper:first-of-type {
+      contain: none;
+    }
+  </style>
+  <div class="lh-scores-wrapper">
+    <div class="lh-scores-container">
+      <div class="pyro">
+        <div class="before"></div>
+        <div class="after"></div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<!-- Lighthouse topbar -->
+<template id="tmpl-lh-topbar">
+  <style>
+    .lh-topbar {
+      position: sticky;
+      top: 0;
+      left: 0;
+      right: 0;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      height: var(--topbar-height);
+      background-color: var(--topbar-background-color);
+      padding: var(--topbar-padding);
+    }
+
+    .lh-topbar__logo {
+      width: var(--topbar-logo-size);
+      height: var(--topbar-logo-size);
+      user-select: none;
+      flex: none;
+    }
+    .lh-topbar__logo .shape {
+      fill: var(--report-text-color);
+    }
+
+    .lh-topbar__url {
+      margin: var(--topbar-padding);
+      text-decoration: none;
+      color: var(--report-text-color);
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
+    .lh-tools {
+      margin-left: auto;
+      will-change: transform;
+    }
+    .lh-tools__button {
+      width: var(--tools-icon-size);
+      height: var(--tools-icon-size);
+      cursor: pointer;
+      margin-right: 5px;
+      /* This is actually a button element, but we want to style it like a transparent div. */
+      display: flex;
+      background: none;
+      color: inherit;
+      border: none;
+      padding: 0;
+      font: inherit;
+      outline: inherit;
+    }
+    .lh-tools__button svg {
+      fill: var(--tools-icon-color);
+    }
+    .dark .lh-tools__button svg {
+      filter: invert(1);
+    }
+    .lh-tools__button.active + .lh-tools__dropdown {
+      opacity: 1;
+      clip: rect(-1px, 187px, 242px, -3px);
+      visibility: visible;
+    }
+    .lh-tools__dropdown {
+      position: absolute;
+      background-color: var(--report-background-color);
+      border: 1px solid var(--report-border-color);
+      border-radius: 3px;
+      padding: calc(var(--default-padding) / 2) 0;
+      cursor: pointer;
+      top: 36px;
+      right: 0;
+      box-shadow: 1px 1px 3px #ccc;
+      min-width: 125px;
+      clip: rect(0, 164px, 0, 0);
+      visibility: hidden;
+      opacity: 0;
+      transition: all 200ms cubic-bezier(0,0,0.2,1);
+    }
+    .lh-tools__dropdown a {
+      display: block;
+      color: currentColor;
+      text-decoration: none;
+      white-space: nowrap;
+      padding: 0 12px;
+      line-height: 2;
+    }
+    .lh-tools__dropdown a:hover,
+    .lh-tools__dropdown a:focus {
+      background-color: var(--color-gray-200);
+      outline: none;
+    }
+    .lh-tools__dropdown .report-icon {
+      cursor: pointer;
+      background-repeat: no-repeat;
+      background-position: 8px 50%;
+      background-size: 18px;
+      background-color: transparent;
+      text-indent: 18px;
+    }
+    .dark .report-icon {
+      color: var(--color-gray-900);
+      filter: invert(1);
+    }
+    .dark .lh-tools__dropdown a:hover,
+    .dark .lh-tools__dropdown a:focus {
+      background-color: #BDBDBD;
+    }
+    /* copy icon needs slight adjustments to look great */
+    .lh-tools__dropdown .report-icon--copy {
+      background-size: 16px;
+      background-position: 9px 50%;
+    }
+    /* save-as-gist option hidden in report */
+    .lh-tools__dropdown .lh-tools--gist {
+      display: none;
+    }
+
+    @media screen and (max-width: 964px) {
+      .lh-tools__dropdown {
+        right: 0;
+        left: initial;
+      }
+    }
+    @media print {
+      .lh-topbar {
+        position: static;
+        margin-left: 0;
+      }
+    }
+  </style>
+
+  <div class="lh-topbar">
+    <!-- Lighthouse logo.  -->
+    <svg class="lh-topbar__logo" viewBox="0 0 24 24">
+      <defs>
+        <linearGradient x1="57.456%" y1="13.086%" x2="18.259%" y2="72.322%" id="lh-topbar__logo--a">
+          <stop stop-color="#262626" stop-opacity=".1" offset="0%"/>
+          <stop stop-color="#262626" stop-opacity="0" offset="100%"/>
+        </linearGradient>
+        <linearGradient x1="100%" y1="50%" x2="0%" y2="50%" id="lh-topbar__logo--b">
+          <stop stop-color="#262626" stop-opacity=".1" offset="0%"/>
+          <stop stop-color="#262626" stop-opacity="0" offset="100%"/>
+        </linearGradient>
+        <linearGradient x1="58.764%" y1="65.756%" x2="36.939%" y2="50.14%" id="lh-topbar__logo--c">
+          <stop stop-color="#262626" stop-opacity=".1" offset="0%"/>
+          <stop stop-color="#262626" stop-opacity="0" offset="100%"/>
+        </linearGradient>
+        <linearGradient x1="41.635%" y1="20.358%" x2="72.863%" y2="85.424%" id="lh-topbar__logo--d">
+          <stop stop-color="#FFF" stop-opacity=".1" offset="0%"/>
+          <stop stop-color="#FFF" stop-opacity="0" offset="100%"/>
+        </linearGradient>
+      </defs>
+      <g fill="none" fill-rule="evenodd">
+        <path d="M12 3l4.125 2.625v3.75H18v2.25h-1.688l1.5 9.375H6.188l1.5-9.375H6v-2.25h1.875V5.648L12 3zm2.201 9.938L9.54 14.633 9 18.028l5.625-2.062-.424-3.028zM12.005 5.67l-1.88 1.207v2.498h3.75V6.86l-1.87-1.19z" fill="#F44B21"/>
+        <path fill="#FFF" d="M14.201 12.938L9.54 14.633 9 18.028l5.625-2.062z"/>
+        <path d="M6 18c-2.042 0-3.95-.01-5.813 0l1.5-9.375h4.326L6 18z" fill="url(#lh-topbar__logo--a)" fill-rule="nonzero" transform="translate(6 3)"/>
+        <path fill="#FFF176" fill-rule="nonzero" d="M13.875 9.375v-2.56l-1.87-1.19-1.88 1.207v2.543z"/>
+        <path fill="url(#lh-topbar__logo--b)" fill-rule="nonzero" d="M0 6.375h6v2.25H0z" transform="translate(6 3)"/>
+        <path fill="url(#lh-topbar__logo--c)" fill-rule="nonzero" d="M6 6.375H1.875v-3.75L6 0z" transform="translate(6 3)"/>
+        <path fill="url(#lh-topbar__logo--d)" fill-rule="nonzero" d="M6 0l4.125 2.625v3.75H12v2.25h-1.688l1.5 9.375H.188l1.5-9.375H0v-2.25h1.875V2.648z" transform="translate(6 3)"/>
+      </g>
+    </svg>
+
+    <a href="" class="lh-topbar__url" target="_blank" rel="noopener"></a>
+
+    <div class="lh-tools">
+      <button id="lh-tools-button" class="report-icon report-icon--share lh-tools__button" title="Tools menu" aria-label="Toggle report tools menu" aria-haspopup="menu" aria-expanded="false" aria-controls="lh-tools-dropdown">
+        <svg width="100%" height="100%" viewBox="0 0 24 24">
+            <path d="M0 0h24v24H0z" fill="none"/>
+            <path d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"/>
+        </svg>
+      </button>
+      <div id="lh-tools-dropdown" role="menu" class="lh-tools__dropdown" aria-labelledby="lh-tools-button">
+         <!-- TODO(i18n): localize tools dropdown -->
+        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--print" data-action="print-summary">Print Summary</a>
+        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--print" data-action="print-expanded">Print Expanded</a>
+        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--copy" data-action="copy">Copy JSON</a>
+        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--download" data-action="save-html">Save as HTML</a>
+        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--download" data-action="save-json">Save as JSON</a>
+        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--open lh-tools--viewer" data-action="open-viewer">Open in Viewer</a>
+        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--open lh-tools--gist" data-action="save-gist">Save as Gist</a>
+        <a role="menuitem" tabindex="-1" href="#" class="report-icon report-icon--dark" data-action="toggle-dark">Toggle Dark Theme</a>
+      </div>
+    </div>
+  </div>
+</template>
+
+<!-- Lighthouse header -->
+<template id="tmpl-lh-heading">
+  <style>
+    /* CSS Fireworks. Originally by Eddie Lin
+       https://codepen.io/paulirish/pen/yEVMbP
+    */
+    .pyro {
+      display: none;
+      z-index: 1;
+      pointer-events: none;
+    }
+    .score100 .pyro {
+      display: block;
+    }
+    .score100 .lh-lighthouse stop:first-child {
+      stop-color: hsla(200, 12%, 95%, 0);
+    }
+    .score100 .lh-lighthouse stop:last-child {
+      stop-color: hsla(65, 81%, 76%, 1);
+    }
+
+    .pyro > .before, .pyro > .after {
+      position: absolute;
+      width: 5px;
+      height: 5px;
+      border-radius: 2.5px;
+      box-shadow: 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff, 0 0 #fff;
+      animation: 1s bang ease-out infinite backwards,  1s gravity ease-in infinite backwards,  5s position linear infinite backwards;
+      animation-delay: 1s, 1s, 1s;
+    }
+
+    .pyro > .after {
+      animation-delay: 2.25s, 2.25s, 2.25s;
+      animation-duration: 1.25s, 1.25s, 6.25s;
+    }
+    .fireworks-paused .pyro > div {
+      animation-play-state: paused;
+    }
+
+    @keyframes bang {
+      to {
+        box-shadow: -70px -115.67px #47ebbc, -28px -99.67px #eb47a4, 58px -31.67px #7eeb47, 13px -141.67px #eb47c5, -19px 6.33px #7347eb, -2px -74.67px #ebd247, 24px -151.67px #eb47e0, 57px -138.67px #b4eb47, -51px -104.67px #479eeb, 62px 8.33px #ebcf47, -93px 0.33px #d547eb, -16px -118.67px #47bfeb, 53px -84.67px #47eb83, 66px -57.67px #eb47bf, -93px -65.67px #91eb47, 30px -13.67px #86eb47, -2px -59.67px #83eb47, -44px 1.33px #eb47eb, 61px -58.67px #47eb73, 5px -22.67px #47e8eb, -66px -28.67px #ebe247, 42px -123.67px #eb5547, -75px 26.33px #7beb47, 15px -52.67px #a147eb, 36px -51.67px #eb8347, -38px -12.67px #eb5547, -46px -59.67px #47eb81, 78px -114.67px #eb47ba, 15px -156.67px #eb47bf, -36px 1.33px #eb4783, -72px -86.67px #eba147, 31px -46.67px #ebe247, -68px 29.33px #47e2eb, -55px 19.33px #ebe047, -56px 27.33px #4776eb, -13px -91.67px #eb5547, -47px -138.67px #47ebc7, -18px -96.67px #eb47ac, 11px -88.67px #4783eb, -67px -28.67px #47baeb, 53px 10.33px #ba47eb, 11px 19.33px #5247eb, -5px -11.67px #eb4791, -68px -4.67px #47eba7, 95px -37.67px #eb478b, -67px -162.67px #eb5d47, -54px -120.67px #eb6847, 49px -12.67px #ebe047, 88px 8.33px #47ebda, 97px 33.33px #eb8147, 6px -71.67px #ebbc47;
+      }
+    }
+    @keyframes gravity {
+      to {
+        transform: translateY(80px);
+        opacity: 0;
+      }
+    }
+    @keyframes position {
+      0%, 19.9% {
+        margin-top: 4%;
+        margin-left: 47%;
+      }
+      20%, 39.9% {
+        margin-top: 7%;
+        margin-left: 30%;
+      }
+      40%, 59.9% {
+        margin-top: 6%;
+        margin-left: 70%;
+      }
+      60%, 79.9% {
+        margin-top: 3%;
+        margin-left: 20%;
+      }
+      80%, 99.9% {
+        margin-top: 3%;
+        margin-left: 80%;
+      }
+    }
+  </style>
+
+  <div class="lh-header-container">
+    <div class="lh-scores-wrapper-placeholder"></div>
+  </div>
+</template>
+
+
+<!-- Lighthouse footer -->
+<template id="tmpl-lh-footer">
+  <style>
+    .lh-footer {
+      padding: var(--footer-padding-vertical) calc(var(--default-padding) * 2);
+      max-width: var(--report-width);
+      margin: 0 auto;
+    }
+    .lh-footer .lh-generated {
+      text-align: center;
+    }
+    .lh-env__title {
+      font-size: var(--env-item-font-size-big);
+      line-height: var(--env-item-line-height-big);
+      text-align: center;
+      padding: var(--score-container-padding);
+    }
+    .lh-env {
+      padding: var(--default-padding) 0;
+    }
+    .lh-env__items {
+      padding-left: 16px;
+      margin: 0 0 var(--audits-margin-bottom);
+      padding: 0;
+    }
+    .lh-env__items .lh-env__item:nth-child(2n) {
+      background-color: var(--env-item-background-color);
+    }
+    .lh-env__item {
+      display: flex;
+      padding: var(--env-item-padding);
+      position: relative;
+    }
+    span.lh-env__name {
+      font-weight: bold;
+      min-width: var(--env-name-min-width);
+      flex: 0.5;
+      padding: 0 8px;
+    }
+    span.lh-env__description {
+      text-align: left;
+      flex: 1;
+    }
+  </style>
+  <footer class="lh-footer">
+    <!-- TODO(i18n): localize runtime settings -->
+    <div class="lh-env">
+      <div class="lh-env__title">Runtime Settings</div>
+      <ul class="lh-env__items">
+        <template id="tmpl-lh-env__items">
+          <li class="lh-env__item">
+            <span class="lh-env__name"></span>
+            <span class="lh-env__description"></span>
+          </li>
+        </template>
+      </ul>
+    </div>
+
+    <div class="lh-generated">
+      Generated by <b>Lighthouse</b> <span class="lh-footer__version"></span> |
+      <a href="https://github.com/GoogleChrome/Lighthouse/issues" target="_blank" rel="noopener">File an issue</a>
+    </div>
+  </footer>
+</template>
+
+<!-- Lighthouse score gauge -->
+<template id="tmpl-lh-gauge">
+  <a href="#" class="lh-gauge__wrapper">
+    <!-- Wrapper exists for the ::before plugin icon. Cannot create pseudo-elements on svgs. -->
+    <div class="lh-gauge__svg-wrapper">
+      <svg viewBox="0 0 120 120" class="lh-gauge">
+        <circle class="lh-gauge-base" r="56" cx="60" cy="60"></circle>
+        <circle class="lh-gauge-arc" transform="rotate(-90 60 60)" r="56" cx="60" cy="60"></circle>
+      </svg>
+    </div>
+    <div class="lh-gauge__percentage"></div>
+    <!-- TODO: should likely be an h2  -->
+    <div class="lh-gauge__label"></div>
+  </a>
+</template>
+
+
+<!-- Lighthouse PWA badge gauge -->
+<template id="tmpl-lh-gauge--pwa">
+  <style>
+    .lh-gauge--pwa .lh-gauge--pwa__component {
+      display: none;
+    }
+    .lh-gauge--pwa__wrapper:not(.lh-badged--all) .lh-gauge--pwa__logo > path {
+      /* Gray logo unless everything is passing. */
+      fill: #B0B0B0;
+    }
+
+    .lh-gauge--pwa__disc {
+      fill: var(--color-gray-200);
+    }
+
+    .lh-gauge--pwa__logo--primary-color {
+      fill: #304FFE;
+    }
+
+    .lh-gauge--pwa__logo--secondary-color {
+      fill: #3D3D3D;
+    }
+    .dark .lh-gauge--pwa__logo--secondary-color {
+      fill: #D8B6B6;
+    }
+
+    /* No passing groups. */
+    .lh-gauge--pwa__wrapper:not([class*='lh-badged--']) .lh-gauge--pwa__na-line {
+      display: inline;
+    }
+    /* Just optimized. Same n/a line as no passing groups. */
+    .lh-gauge--pwa__wrapper.lh-badged--pwa-optimized:not(.lh-badged--pwa-installable):not(.lh-badged--pwa-fast-reliable) .lh-gauge--pwa__na-line {
+      display: inline;
+    }
+
+    /* Just fast and reliable. */
+    .lh-gauge--pwa__wrapper.lh-badged--pwa-fast-reliable:not(.lh-badged--pwa-installable) .lh-gauge--pwa__fast-reliable-badge {
+      display: inline;
+    }
+
+    /* Just installable. */
+    .lh-gauge--pwa__wrapper.lh-badged--pwa-installable:not(.lh-badged--pwa-fast-reliable) .lh-gauge--pwa__installable-badge {
+      display: inline;
+    }
+
+    /* Fast and reliable and installable. */
+    .lh-gauge--pwa__wrapper.lh-badged--pwa-fast-reliable.lh-badged--pwa-installable .lh-gauge--pwa__fast-reliable-installable-badges {
+      display: inline;
+    }
+
+    /* All passing groups. */
+    .lh-gauge--pwa__wrapper.lh-badged--all .lh-gauge--pwa__check-circle {
+      display: inline;
+    }
+  </style>
+
+  <a href="#" class="lh-gauge__wrapper lh-gauge--pwa__wrapper">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 60" class="lh-gauge lh-gauge--pwa">
+      <defs>
+        <linearGradient id="lh-gauge--pwa__check-circle__gradient" x1="50%" y1="0%" x2="50%" y2="100%">
+          <stop stop-color="#00C852" offset="0%"></stop>
+          <stop stop-color="#009688" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient id="lh-gauge--pwa__installable__shadow-gradient" x1="76.056%" x2="24.111%" y1="82.995%" y2="24.735%">
+          <stop stop-color="#A5D6A7" offset="0%"></stop>
+          <stop stop-color="#80CBC4" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient id="lh-gauge--pwa__fast-reliable__shadow-gradient" x1="76.056%" y1="82.995%" x2="25.678%" y2="26.493%">
+          <stop stop-color="#64B5F6" offset="0%"></stop>
+          <stop stop-color="#2979FF" offset="100%"></stop>
+        </linearGradient>
+
+        <g id="lh-gauge--pwa__fast-reliable-badge">
+          <circle fill="#FFFFFF" cx="10" cy="10" r="10"></circle>
+          <path fill="#304FFE" d="M10 3.58l5.25 2.34v3.5c0 3.23-2.24 6.26-5.25 7-3.01-.74-5.25-3.77-5.25-7v-3.5L10 3.58zm-.47 10.74l2.76-4.83.03-.07c.04-.08 0-.24-.22-.24h-1.64l.47-3.26h-.47l-2.7 4.77c-.02.01.05-.1-.04.05-.09.16-.1.31.18.31h1.63l-.47 3.27h.47z"/>
+        </g>
+        <g id="lh-gauge--pwa__installable-badge">
+          <circle fill="#FFFFFF" cx="10" cy="10" r="10"></circle>
+          <path fill="#009688" d="M10 4.167A5.835 5.835 0 0 0 4.167 10 5.835 5.835 0 0 0 10 15.833 5.835 5.835 0 0 0 15.833 10 5.835 5.835 0 0 0 10 4.167zm2.917 6.416h-2.334v2.334H9.417v-2.334H7.083V9.417h2.334V7.083h1.166v2.334h2.334v1.166z"/>
+        </g>
+      </defs>
+
+      <g stroke="none" fill-rule="nonzero">
+        <!-- Background and PWA logo (color by default) -->
+        <circle class="lh-gauge--pwa__disc" cx="30" cy="30" r="30"></circle>
+        <g class="lh-gauge--pwa__logo">
+          <path class="lh-gauge--pwa__logo--secondary-color" d="M35.66 19.39l.7-1.75h2L37.4 15 38.6 12l3.4 9h-2.51l-.58-1.61z"/>
+          <path class="lh-gauge--pwa__logo--primary-color" d="M33.52 21l3.65-9h-2.42l-2.5 5.82L30.5 12h-1.86l-1.9 5.82-1.35-2.65-1.21 3.72L25.4 21h2.38l1.72-5.2 1.64 5.2z"/>
+          <path class="lh-gauge--pwa__logo--secondary-color" fill-rule="nonzero" d="M20.3 17.91h1.48c.45 0 .85-.05 1.2-.15l.39-1.18 1.07-3.3a2.64 2.64 0 0 0-.28-.37c-.55-.6-1.36-.91-2.42-.91H18v9h2.3V17.9zm1.96-3.84c.22.22.33.5.33.87 0 .36-.1.65-.29.87-.2.23-.59.35-1.15.35h-.86v-2.41h.87c.52 0 .89.1 1.1.32z"/>
+        </g>
+
+        <!-- No badges. -->
+        <rect class="lh-gauge--pwa__component lh-gauge--pwa__na-line" fill="#FFFFFF" x="20" y="32" width="20" height="4" rx="2"></rect>
+
+        <!-- Just fast and reliable. -->
+        <g class="lh-gauge--pwa__component lh-gauge--pwa__fast-reliable-badge" transform="translate(20, 29)">
+          <path fill="url(#lh-gauge--pwa__fast-reliable__shadow-gradient)" d="M33.63 19.49A30 30 0 0 1 16.2 30.36L3 17.14 17.14 3l16.49 16.49z"/>
+          <use href="#lh-gauge--pwa__fast-reliable-badge" />
+        </g>
+
+        <!-- Just installable. -->
+        <g class="lh-gauge--pwa__component lh-gauge--pwa__installable-badge" transform="translate(20, 29)">
+          <path fill="url(#lh-gauge--pwa__installable__shadow-gradient)" d="M33.629 19.487c-4.272 5.453-10.391 9.39-17.415 10.869L3 17.142 17.142 3 33.63 19.487z"/>
+          <use href="#lh-gauge--pwa__installable-badge" />
+        </g>
+
+        <!-- Fast and reliable and installable. -->
+        <g class="lh-gauge--pwa__component lh-gauge--pwa__fast-reliable-installable-badges">
+          <g transform="translate(8, 29)"> <!-- fast and reliable -->
+            <path fill="url(#lh-gauge--pwa__fast-reliable__shadow-gradient)" d="M16.321 30.463L3 17.143 17.142 3l22.365 22.365A29.864 29.864 0 0 1 22 31c-1.942 0-3.84-.184-5.679-.537z"/>
+            <use href="#lh-gauge--pwa__fast-reliable-badge" />
+          </g>
+          <g transform="translate(32, 29)"> <!-- installable -->
+            <path fill="url(#lh-gauge--pwa__installable__shadow-gradient)" d="M25.982 11.84a30.107 30.107 0 0 1-13.08 15.203L3 17.143 17.142 3l8.84 8.84z"/>
+            <use href="#lh-gauge--pwa__installable-badge" />
+          </g>
+        </g>
+
+        <!-- Full PWA. -->
+        <g class="lh-gauge--pwa__component lh-gauge--pwa__check-circle" transform="translate(18, 28)">
+          <circle fill="#FFFFFF" cx="12" cy="12" r="12"></circle>
+          <path fill="url(#lh-gauge--pwa__check-circle__gradient)" d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"></path>
+        </g>
+      </g>
+    </svg>
+
+    <div class="lh-gauge__label"></div>
+  </a>
+</template>
+
+<!-- Lighthouse crtiical request chains component -->
+<template id="tmpl-lh-crc">
+  <div class="lh-crc-container">
+    <style>
+      .lh-crc .tree-marker {
+        width: 12px;
+        height: 26px;
+        display: block;
+        float: left;
+        background-position: top left;
+      }
+      .lh-crc .horiz-down {
+        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><g fill="%23D8D8D8" fill-rule="evenodd"><path d="M16 12v2H-2v-2z"/><path d="M9 12v14H7V12z"/></g></svg>');
+      }
+      .lh-crc .right {
+        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M16 12v2H0v-2z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+      }
+      .lh-crc .up-right {
+        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v14H7zm2 12h7v2H9z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+      }
+      .lh-crc .vert-right {
+        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v27H7zm2 12h7v2H9z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+      }
+      .lh-crc .vert {
+        background: url('data:image/svg+xml;utf8,<svg width="16" height="26" viewBox="0 0 16 26" xmlns="http://www.w3.org/2000/svg"><path d="M7 0h2v26H7z" fill="%23D8D8D8" fill-rule="evenodd"/></svg>');
+      }
+      .lh-crc .crc-tree {
+        font-size: 14px;
+        width: 100%;
+        overflow-x: auto;
+      }
+      .lh-crc .crc-node {
+        height: 26px;
+        line-height: 26px;
+        white-space: nowrap;
+      }
+      .lh-crc .crc-node__tree-value {
+        margin-left: 10px;
+      }
+      .lh-crc .crc-node__tree-value div {
+        display: inline;
+      }
+      .lh-crc .crc-node__chain-duration {
+        font-weight: 700;
+      }
+      .lh-crc .crc-initial-nav {
+        color: #595959;
+        font-style: italic;
+      }
+      .lh-crc__summary-value {
+        margin-bottom: 10px;
+      }
+    </style>
+    <div>
+      <div class="lh-crc__summary-value">
+        <span class="lh-crc__longest_duration_label"></span> <b class="lh-crc__longest_duration"></b>
+      </div>
+    </div>
+    <div class="lh-crc">
+      <div class="crc-initial-nav"></div>
+      <!-- stamp for each chain -->
+      <template id="tmpl-lh-crc__chains">
+        <div class="crc-node">
+          <span class="crc-node__tree-marker">
+
+          </span>
+          <span class="crc-node__tree-value">
+
+          </span>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>
+
+<template id="tmpl-lh-3p-filter">
+  <style>
+    .lh-3p-filter {
+      background-color: var(--table-higlight-background-color);
+      color: var(--color-gray-600);
+      float: right;
+      padding: 6px;
+    }
+    .lh-3p-filter-label, .lh-3p-filter-input {
+      vertical-align: middle;
+      user-select: none;
+    }
+    .lh-3p-filter-input:disabled + .lh-3p-ui-string {
+      text-decoration: line-through;
+    }
+  </style>
+  <div class="lh-3p-filter">
+    <label class="lh-3p-filter-label">
+      <input type="checkbox" class="lh-3p-filter-input" checked />
+      <span class="lh-3p-ui-string">Show 3rd party resources</span> (<span class="lh-3p-filter-count"></span>)
+    </label>
+  </div>
+</template>
+
+<!-- Lighthouse snippet component -->
+<template id="tmpl-lh-snippet">
+    <div class="lh-snippet">
+      <style>
+          :root {
+            --snippet-highlight-light: #fbf1f2;
+            --snippet-highlight-dark: #ffd6d8;
+          }
+
+         .lh-snippet__header {
+          position: relative;
+          overflow: hidden;
+          padding: 10px;
+          border-bottom: none;
+          color: var(--snippet-color);
+          background-color: var(--snippet-background-color);
+          border: 1px solid var(--report-border-color-secondary);
+        }
+        .lh-snippet__title {
+          font-weight: bold;
+          float: left;
+        }
+        .lh-snippet__node {
+          float: left;
+          margin-left: 4px;
+        }
+        .lh-snippet__toggle-expand {
+          padding: 1px 7px;
+          margin-top: -1px;
+          margin-right: -7px;
+          float: right;
+          background: transparent;
+          border: none;
+          cursor: pointer;
+          font-size: 14px;
+          color: #0c50c7;
+        }
+
+        .lh-snippet__snippet {
+          overflow: auto;
+          border: 1px solid var(--report-border-color-secondary);
+        }
+        /* Container needed so that all children grow to the width of the scroll container */
+        .lh-snippet__snippet-inner {
+          display: inline-block;
+          min-width: 100%;
+        }
+
+        .lh-snippet:not(.lh-snippet--expanded) .lh-snippet__show-if-expanded {
+          display: none;
+        }
+        .lh-snippet.lh-snippet--expanded .lh-snippet__show-if-collapsed {
+          display: none;
+        }
+
+        .lh-snippet__line {
+          background: white;
+          white-space: pre;
+          display: flex;
+        }
+        .lh-snippet__line:not(.lh-snippet__line--message):first-child {
+          padding-top: 4px;
+        }
+        .lh-snippet__line:not(.lh-snippet__line--message):last-child {
+          padding-bottom: 4px;
+        }
+        .lh-snippet__line--content-highlighted {
+          background: var(--snippet-highlight-dark);
+        }
+        .lh-snippet__line--message {
+          background: var(--snippet-highlight-light);
+        }
+        .lh-snippet__line--message .lh-snippet__line-number {
+          padding-top: 10px;
+          padding-bottom: 10px;
+        }
+        .lh-snippet__line--message code {
+          padding: 10px;
+          padding-left: 5px;
+          color: var(--color-fail);
+          font-family: var(--report-font-family);
+        }
+        .lh-snippet__line--message code {
+          white-space: normal;
+        }
+        .lh-snippet__line-icon {
+          padding-top: 10px;
+          display: none;
+        }
+        .lh-snippet__line--message .lh-snippet__line-icon {
+          display: block;
+        }
+        .lh-snippet__line-icon:before {
+          content: "";
+          display: inline-block;
+          vertical-align: middle;
+          margin-right: 4px;
+          width: var(--score-icon-size);
+          height: var(--score-icon-size);
+          background-image: var(--fail-icon-url);
+        }
+        .lh-snippet__line-number {
+          flex-shrink: 0;
+          width: 40px;
+          text-align: right;
+          font-family: monospace;
+          padding-right: 5px;
+          margin-right: 5px;
+          color: var(--color-gray-600);
+          user-select: none;
+        }
+      </style>
+      <template id="tmpl-lh-snippet__header">
+        <div class="lh-snippet__header">
+          <div class="lh-snippet__title"></div>
+          <div class="lh-snippet__node"></div>
+          <button class="lh-snippet__toggle-expand">
+            <span class="lh-snippet__btn-label-collapse lh-snippet__show-if-expanded"></span>
+            <span class="lh-snippet__btn-label-expand lh-snippet__show-if-collapsed"></span>
+          </button>
+        </div>
+      </template>
+      <template id="tmpl-lh-snippet__content">
+        <div class="lh-snippet__snippet">
+          <div class="lh-snippet__snippet-inner"></div>
+        </div>
+      </template>
+      <template id="tmpl-lh-snippet__line">
+          <div class="lh-snippet__line">
+            <div class="lh-snippet__line-number"></div>
+            <div class="lh-snippet__line-icon"></div>
+            <code></code>
+          </div>
+        </template>
+    </div>
+  </template>
+
+</div>
+
+  <main><!-- report populated here --></main>
+
+  <div id="lh-log"></div>
+
+  <script>/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* globals self, URL */
+
+const ELLIPSIS = '\u2026';
+const NBSP = '\xa0';
+const PASS_THRESHOLD = 0.9;
+const SCREENSHOT_PREFIX = 'data:image/jpeg;base64,';
+
+const RATINGS = {
+  PASS: {label: 'pass', minScore: PASS_THRESHOLD},
+  AVERAGE: {label: 'average', minScore: 0.5},
+  FAIL: {label: 'fail'},
+  ERROR: {label: 'error'},
+};
+
+// 25 most used tld plus one domains (aka public suffixes) from http archive.
+// @see https://github.com/GoogleChrome/lighthouse/pull/5065#discussion_r191926212
+// The canonical list is https://publicsuffix.org/learn/ but we're only using subset to conserve bytes
+const listOfTlds = [
+  'com', 'co', 'gov', 'edu', 'ac', 'org', 'go', 'gob', 'or', 'net', 'in', 'ne', 'nic', 'gouv',
+  'web', 'spb', 'blog', 'jus', 'kiev', 'mil', 'wi', 'qc', 'ca', 'bel', 'on',
+];
+
+class Util {
+  static get PASS_THRESHOLD() {
+    return PASS_THRESHOLD;
+  }
+
+  static get MS_DISPLAY_VALUE() {
+    return `%10d${NBSP}ms`;
+  }
+
+  /**
+   * Returns a new LHR that's reshaped for slightly better ergonomics within the report rendereer.
+   * Also, sets up the localized UI strings used within renderer and makes changes to old LHRs to be
+   * compatible with current renderer.
+   * The LHR passed in is not mutated.
+   * TODO(team): we all agree the LHR shape change is technical debt we should fix
+   * @param {LH.Result} result
+   * @return {LH.ReportResult}
+   */
+  static prepareReportResult(result) {
+    // If any mutations happen to the report within the renderers, we want the original object untouched
+    const clone = /** @type {LH.ReportResult} */ (JSON.parse(JSON.stringify(result)));
+
+    // If LHR is older (≤3.0.3), it has no locale setting. Set default.
+    if (!clone.configSettings.locale) {
+      clone.configSettings.locale = 'en';
+    }
+
+    for (const audit of Object.values(clone.audits)) {
+      // Turn 'not-applicable' (LHR <4.0) and 'not_applicable' (older proto versions)
+      // into 'notApplicable' (LHR ≥4.0).
+      // @ts-ignore tsc rightly flags that these values shouldn't occur.
+      // eslint-disable-next-line max-len
+      if (audit.scoreDisplayMode === 'not_applicable' || audit.scoreDisplayMode === 'not-applicable') {
+        audit.scoreDisplayMode = 'notApplicable';
+      }
+
+      if (audit.details) {
+        // Turn `auditDetails.type` of undefined (LHR <4.2) and 'diagnostic' (LHR <5.0)
+        // into 'debugdata' (LHR ≥5.0).
+        // @ts-ignore tsc rightly flags that these values shouldn't occur.
+        if (audit.details.type === undefined || audit.details.type === 'diagnostic') {
+          audit.details.type = 'debugdata';
+        }
+
+        // Add the jpg data URL prefix to filmstrip screenshots without them (LHR <5.0).
+        if (audit.details.type === 'filmstrip') {
+          for (const screenshot of audit.details.items) {
+            if (!screenshot.data.startsWith(SCREENSHOT_PREFIX)) {
+              screenshot.data = SCREENSHOT_PREFIX + screenshot.data;
+            }
+          }
+        }
+      }
+    }
+
+    // Set locale for number/date formatting and grab localized renderer strings from the LHR.
+    Util.setNumberDateLocale(clone.configSettings.locale);
+    if (clone.i18n && clone.i18n.rendererFormattedStrings) {
+      Util.updateAllUIStrings(clone.i18n.rendererFormattedStrings);
+    }
+
+    // For convenience, smoosh all AuditResults into their auditRef (which has just weight & group)
+    if (typeof clone.categories !== 'object') throw new Error('No categories provided.');
+    for (const category of Object.values(clone.categories)) {
+      category.auditRefs.forEach(auditRef => {
+        const result = clone.audits[auditRef.id];
+        auditRef.result = result;
+
+        // attach the stackpacks to the auditRef object
+        if (clone.stackPacks) {
+          clone.stackPacks.forEach(pack => {
+            if (pack.descriptions[auditRef.id]) {
+              auditRef.stackPacks = auditRef.stackPacks || [];
+              auditRef.stackPacks.push({
+                title: pack.title,
+                iconDataURL: pack.iconDataURL,
+                description: pack.descriptions[auditRef.id],
+              });
+            }
+          });
+        }
+      });
+    }
+
+    return clone;
+  }
+
+
+  /**
+   * @param {LH.I18NRendererStrings} rendererFormattedStrings
+   */
+  static updateAllUIStrings(rendererFormattedStrings) {
+    // TODO(i18n): don't mutate these here but on the LHR and pass that around everywhere
+    for (const [key, value] of Object.entries(rendererFormattedStrings)) {
+      Util.UIStrings[key] = value;
+    }
+  }
+
+  /**
+   * Used to determine if the "passed" for the purposes of showing up in the "failed" or "passed"
+   * sections of the report.
+   *
+   * @param {{score: (number|null), scoreDisplayMode: string}} audit
+   * @return {boolean}
+   */
+  static showAsPassed(audit) {
+    switch (audit.scoreDisplayMode) {
+      case 'manual':
+      case 'notApplicable':
+        return true;
+      case 'error':
+      case 'informative':
+        return false;
+      case 'numeric':
+      case 'binary':
+      default:
+        return Number(audit.score) >= RATINGS.PASS.minScore;
+    }
+  }
+
+  /**
+   * Convert a score to a rating label.
+   * @param {number|null} score
+   * @param {string=} scoreDisplayMode
+   * @return {string}
+   */
+  static calculateRating(score, scoreDisplayMode) {
+    // Handle edge cases first, manual and not applicable receive 'pass', errored audits receive 'error'
+    if (scoreDisplayMode === 'manual' || scoreDisplayMode === 'notApplicable') {
+      return RATINGS.PASS.label;
+    } else if (scoreDisplayMode === 'error') {
+      return RATINGS.ERROR.label;
+    } else if (score === null) {
+      return RATINGS.FAIL.label;
+    }
+
+    // At this point, we're rating a standard binary/numeric audit
+    let rating = RATINGS.FAIL.label;
+    if (score >= RATINGS.PASS.minScore) {
+      rating = RATINGS.PASS.label;
+    } else if (score >= RATINGS.AVERAGE.minScore) {
+      rating = RATINGS.AVERAGE.label;
+    }
+    return rating;
+  }
+
+  /**
+   * Format number.
+   * @param {number} number
+   * @param {number=} granularity Number of decimal places to include. Defaults to 0.1.
+   * @return {string}
+   */
+  static formatNumber(number, granularity = 0.1) {
+    const coarseValue = Math.round(number / granularity) * granularity;
+    return Util.numberFormatter.format(coarseValue);
+  }
+
+  /**
+   * @param {number} size
+   * @param {number=} granularity Controls how coarse the displayed value is, defaults to .01
+   * @return {string}
+   */
+  static formatBytesToKB(size, granularity = 0.1) {
+    const kbs = Util.numberFormatter.format(Math.round(size / 1024 / granularity) * granularity);
+    return `${kbs}${NBSP}KB`;
+  }
+
+  /**
+   * @param {number} ms
+   * @param {number=} granularity Controls how coarse the displayed value is, defaults to 10
+   * @return {string}
+   */
+  static formatMilliseconds(ms, granularity = 10) {
+    const coarseTime = Math.round(ms / granularity) * granularity;
+    return `${Util.numberFormatter.format(coarseTime)}${NBSP}ms`;
+  }
+
+  /**
+   * @param {number} ms
+   * @param {number=} granularity Controls how coarse the displayed value is, defaults to 0.1
+   * @return {string}
+   */
+  static formatSeconds(ms, granularity = 0.1) {
+    const coarseTime = Math.round(ms / 1000 / granularity) * granularity;
+    return `${Util.numberFormatter.format(coarseTime)}${NBSP}s`;
+  }
+
+  /**
+   * Format time.
+   * @param {string} date
+   * @return {string}
+   */
+  static formatDateTime(date) {
+    /** @type {Intl.DateTimeFormatOptions} */
+    const options = {
+      month: 'short', day: 'numeric', year: 'numeric',
+      hour: 'numeric', minute: 'numeric', timeZoneName: 'short',
+    };
+    let formatter = new Intl.DateTimeFormat(Util.numberDateLocale, options);
+
+    // Force UTC if runtime timezone could not be detected.
+    // See https://github.com/GoogleChrome/lighthouse/issues/1056
+    const tz = formatter.resolvedOptions().timeZone;
+    if (!tz || tz.toLowerCase() === 'etc/unknown') {
+      options.timeZone = 'UTC';
+      formatter = new Intl.DateTimeFormat(Util.numberDateLocale, options);
+    }
+    return formatter.format(new Date(date));
+  }
+  /**
+   * Converts a time in milliseconds into a duration string, i.e. `1d 2h 13m 52s`
+   * @param {number} timeInMilliseconds
+   * @return {string}
+   */
+  static formatDuration(timeInMilliseconds) {
+    let timeInSeconds = timeInMilliseconds / 1000;
+    if (Math.round(timeInSeconds) === 0) {
+      return 'None';
+    }
+
+    /** @type {Array<string>} */
+    const parts = [];
+    const unitLabels = /** @type {Object<string, number>} */ ({
+      d: 60 * 60 * 24,
+      h: 60 * 60,
+      m: 60,
+      s: 1,
+    });
+
+    Object.keys(unitLabels).forEach(label => {
+      const unit = unitLabels[label];
+      const numberOfUnits = Math.floor(timeInSeconds / unit);
+      if (numberOfUnits > 0) {
+        timeInSeconds -= numberOfUnits * unit;
+        parts.push(`${numberOfUnits}\xa0${label}`);
+      }
+    });
+
+    return parts.join(' ');
+  }
+
+  /**
+   * Split a string by markdown code spans (enclosed in `backticks`), splitting
+   * into segments that were enclosed in backticks (marked as `isCode === true`)
+   * and those that outside the backticks (`isCode === false`).
+   * @param {string} text
+   * @return {Array<{isCode: true, text: string}|{isCode: false, text: string}>}
+   */
+  static splitMarkdownCodeSpans(text) {
+    /** @type {Array<{isCode: true, text: string}|{isCode: false, text: string}>} */
+    const segments = [];
+
+    // Split on backticked code spans.
+    const parts = text.split(/`(.*?)`/g);
+    for (let i = 0; i < parts.length; i ++) {
+      const text = parts[i];
+
+      // Empty strings are an artifact of splitting, not meaningful.
+      if (!text) continue;
+
+      // Alternates between plain text and code segments.
+      const isCode = i % 2 !== 0;
+      segments.push({
+        isCode,
+        text,
+      });
+    }
+
+    return segments;
+  }
+
+  /**
+   * Split a string on markdown links (e.g. [some link](https://...)) into
+   * segments of plain text that weren't part of a link (marked as
+   * `isLink === false`), and segments with text content and a URL that did make
+   * up a link (marked as `isLink === true`).
+   * @param {string} text
+   * @return {Array<{isLink: true, text: string, linkHref: string}|{isLink: false, text: string}>}
+   */
+  static splitMarkdownLink(text) {
+    /** @type {Array<{isLink: true, text: string, linkHref: string}|{isLink: false, text: string}>} */
+    const segments = [];
+
+    const parts = text.split(/\[([^\]]+?)\]\((https?:\/\/.*?)\)/g);
+    while (parts.length) {
+      // Shift off the same number of elements as the pre-split and capture groups.
+      const [preambleText, linkText, linkHref] = parts.splice(0, 3);
+
+      if (preambleText) { // Skip empty text as it's an artifact of splitting, not meaningful.
+        segments.push({
+          isLink: false,
+          text: preambleText,
+        });
+      }
+
+      // Append link if there are any.
+      if (linkText && linkHref) {
+        segments.push({
+          isLink: true,
+          text: linkText,
+          linkHref,
+        });
+      }
+    }
+
+    return segments;
+  }
+
+  /**
+   * @param {URL} parsedUrl
+   * @param {{numPathParts?: number, preserveQuery?: boolean, preserveHost?: boolean}=} options
+   * @return {string}
+   */
+  static getURLDisplayName(parsedUrl, options) {
+    // Closure optional properties aren't optional in tsc, so fallback needs undefined  values.
+    options = options || {numPathParts: undefined, preserveQuery: undefined,
+      preserveHost: undefined};
+    const numPathParts = options.numPathParts !== undefined ? options.numPathParts : 2;
+    const preserveQuery = options.preserveQuery !== undefined ? options.preserveQuery : true;
+    const preserveHost = options.preserveHost || false;
+
+    let name;
+
+    if (parsedUrl.protocol === 'about:' || parsedUrl.protocol === 'data:') {
+      // Handle 'about:*' and 'data:*' URLs specially since they have no path.
+      name = parsedUrl.href;
+    } else {
+      name = parsedUrl.pathname;
+      const parts = name.split('/').filter(part => part.length);
+      if (numPathParts && parts.length > numPathParts) {
+        name = ELLIPSIS + parts.slice(-1 * numPathParts).join('/');
+      }
+
+      if (preserveHost) {
+        name = `${parsedUrl.host}/${name.replace(/^\//, '')}`;
+      }
+      if (preserveQuery) {
+        name = `${name}${parsedUrl.search}`;
+      }
+    }
+
+    const MAX_LENGTH = 64;
+    // Always elide hexadecimal hash
+    name = name.replace(/([a-f0-9]{7})[a-f0-9]{13}[a-f0-9]*/g, `$1${ELLIPSIS}`);
+    // Also elide other hash-like mixed-case strings
+    name = name.replace(/([a-zA-Z0-9-_]{9})(?=.*[a-z])(?=.*[A-Z])(?=.*[0-9])[a-zA-Z0-9-_]{10,}/g,
+      `$1${ELLIPSIS}`);
+    // Also elide long number sequences
+    name = name.replace(/(\d{3})\d{6,}/g, `$1${ELLIPSIS}`);
+    // Merge any adjacent ellipses
+    name = name.replace(/\u2026+/g, ELLIPSIS);
+
+    // Elide query params first
+    if (name.length > MAX_LENGTH && name.includes('?')) {
+      // Try to leave the first query parameter intact
+      name = name.replace(/\?([^=]*)(=)?.*/, `?$1$2${ELLIPSIS}`);
+
+      // Remove it all if it's still too long
+      if (name.length > MAX_LENGTH) {
+        name = name.replace(/\?.*/, `?${ELLIPSIS}`);
+      }
+    }
+
+    // Elide too long names next
+    if (name.length > MAX_LENGTH) {
+      const dotIndex = name.lastIndexOf('.');
+      if (dotIndex >= 0) {
+        name = name.slice(0, MAX_LENGTH - 1 - (name.length - dotIndex)) +
+          // Show file extension
+          `${ELLIPSIS}${name.slice(dotIndex)}`;
+      } else {
+        name = name.slice(0, MAX_LENGTH - 1) + ELLIPSIS;
+      }
+    }
+
+    return name;
+  }
+
+  /**
+   * Split a URL into a file, hostname and origin for easy display.
+   * @param {string} url
+   * @return {{file: string, hostname: string, origin: string}}
+   */
+  static parseURL(url) {
+    const parsedUrl = new URL(url);
+    return {
+      file: Util.getURLDisplayName(parsedUrl),
+      hostname: parsedUrl.hostname,
+      origin: parsedUrl.origin,
+    };
+  }
+
+  /**
+   * @param {string|URL} value
+   * @return {URL}
+   */
+  static createOrReturnURL(value) {
+    if (value instanceof URL) {
+      return value;
+    }
+
+    return new URL(value);
+  }
+
+  /**
+   * Gets the tld of a domain
+   *
+   * @param {string} hostname
+   * @return {string} tld
+   */
+  static getTld(hostname) {
+    const tlds = hostname.split('.').slice(-2);
+
+    if (!listOfTlds.includes(tlds[0])) {
+      return `.${tlds[tlds.length - 1]}`;
+    }
+
+    return `.${tlds.join('.')}`;
+  }
+
+  /**
+   * Returns a primary domain for provided hostname (e.g. www.example.com -> example.com).
+   * @param {string|URL} url hostname or URL object
+   * @returns {string}
+   */
+  static getRootDomain(url) {
+    const hostname = Util.createOrReturnURL(url).hostname;
+    const tld = Util.getTld(hostname);
+
+    // tld is .com or .co.uk which means we means that length is 1 to big
+    // .com => 2 & .co.uk => 3
+    const splitTld = tld.split('.');
+
+    // get TLD + root domain
+    return hostname.split('.').slice(-splitTld.length).join('.');
+  }
+
+  /**
+   * @param {LH.Config.Settings} settings
+   * @return {Array<{name: string, description: string}>}
+   */
+  static getEnvironmentDisplayValues(settings) {
+    const emulationDesc = Util.getEmulationDescriptions(settings);
+
+    return [
+      {
+        name: 'Device',
+        description: emulationDesc.deviceEmulation,
+      },
+      {
+        name: 'Network throttling',
+        description: emulationDesc.networkThrottling,
+      },
+      {
+        name: 'CPU throttling',
+        description: emulationDesc.cpuThrottling,
+      },
+    ];
+  }
+
+  /**
+   * @param {LH.Config.Settings} settings
+   * @return {{deviceEmulation: string, networkThrottling: string, cpuThrottling: string, summary: string}}
+   */
+  static getEmulationDescriptions(settings) {
+    let cpuThrottling;
+    let networkThrottling;
+    let summary;
+
+    const throttling = settings.throttling;
+
+    switch (settings.throttlingMethod) {
+      case 'provided':
+        cpuThrottling = 'Provided by environment';
+        networkThrottling = 'Provided by environment';
+        summary = 'No throttling applied';
+        break;
+      case 'devtools': {
+        const {cpuSlowdownMultiplier, requestLatencyMs} = throttling;
+        cpuThrottling = `${Util.formatNumber(cpuSlowdownMultiplier)}x slowdown (DevTools)`;
+        networkThrottling = `${Util.formatNumber(requestLatencyMs)}${NBSP}ms HTTP RTT, ` +
+          `${Util.formatNumber(throttling.downloadThroughputKbps)}${NBSP}Kbps down, ` +
+          `${Util.formatNumber(throttling.uploadThroughputKbps)}${NBSP}Kbps up (DevTools)`;
+        summary = 'Throttled Slow 4G network';
+        break;
+      }
+      case 'simulate': {
+        const {cpuSlowdownMultiplier, rttMs, throughputKbps} = throttling;
+        cpuThrottling = `${Util.formatNumber(cpuSlowdownMultiplier)}x slowdown (Simulated)`;
+        networkThrottling = `${Util.formatNumber(rttMs)}${NBSP}ms TCP RTT, ` +
+          `${Util.formatNumber(throughputKbps)}${NBSP}Kbps throughput (Simulated)`;
+        summary = 'Simulated Slow 4G network';
+        break;
+      }
+      default:
+        cpuThrottling = 'Unknown';
+        networkThrottling = 'Unknown';
+        summary = 'Unknown';
+    }
+
+    let deviceEmulation = 'No emulation';
+    if (settings.emulatedFormFactor === 'mobile') deviceEmulation = 'Emulated Nexus 5X';
+    if (settings.emulatedFormFactor === 'desktop') deviceEmulation = 'Emulated Desktop';
+
+    return {
+      deviceEmulation,
+      cpuThrottling,
+      networkThrottling,
+      summary: `${deviceEmulation}, ${summary}`,
+    };
+  }
+
+  /**
+   * Set the locale to be used for Util's number and date formatting functions.
+   * @param {LH.Locale} locale
+   */
+  static setNumberDateLocale(locale) {
+    // When testing, use a locale with more exciting numeric formatting
+    if (locale === 'en-XA') locale = 'de';
+
+    Util.numberDateLocale = locale;
+    Util.numberFormatter = new Intl.NumberFormat(locale);
+  }
+
+  /**
+   * Returns only lines that are near a message, or the first few lines if there are
+   * no line messages.
+   * @param {LH.Audit.Details.SnippetValue['lines']} lines
+   * @param {LH.Audit.Details.SnippetValue['lineMessages']} lineMessages
+   * @param {number} surroundingLineCount Number of lines to include before and after
+   * the message. If this is e.g. 2 this function might return 5 lines.
+   */
+  static filterRelevantLines(lines, lineMessages, surroundingLineCount) {
+    if (lineMessages.length === 0) {
+      // no lines with messages, just return the first bunch of lines
+      return lines.slice(0, surroundingLineCount * 2 + 1);
+    }
+
+    const minGapSize = 3;
+    const lineNumbersToKeep = new Set();
+    // Sort messages so we can check lineNumbersToKeep to see how big the gap to
+    // the previous line is.
+    lineMessages = lineMessages.sort((a, b) => (a.lineNumber || 0) - (b.lineNumber || 0));
+    lineMessages.forEach(({lineNumber}) => {
+      let firstSurroundingLineNumber = lineNumber - surroundingLineCount;
+      let lastSurroundingLineNumber = lineNumber + surroundingLineCount;
+
+      while (firstSurroundingLineNumber < 1) {
+        // make sure we still show (surroundingLineCount * 2 + 1) lines in total
+        firstSurroundingLineNumber++;
+        lastSurroundingLineNumber++;
+      }
+      // If only a few lines would be omitted normally then we prefer to include
+      // extra lines to avoid the tiny gap
+      if (lineNumbersToKeep.has(firstSurroundingLineNumber - minGapSize - 1)) {
+        firstSurroundingLineNumber -= minGapSize;
+      }
+      for (let i = firstSurroundingLineNumber; i <= lastSurroundingLineNumber; i++) {
+        const surroundingLineNumber = i;
+        lineNumbersToKeep.add(surroundingLineNumber);
+      }
+    });
+
+    return lines.filter(line => lineNumbersToKeep.has(line.lineNumber));
+  }
+
+  /**
+   * @param {string} categoryId
+   */
+  static isPluginCategory(categoryId) {
+    return categoryId.startsWith('lighthouse-plugin-');
+  }
+}
+
+/**
+ * This value is updated on each run to the locale of the report
+ * @type {LH.Locale}
+ */
+Util.numberDateLocale = 'en';
+
+/**
+ * This value stays in sync with Util.numberDateLocale.
+ * @type {Intl.NumberFormat}
+ */
+Util.numberFormatter = new Intl.NumberFormat(Util.numberDateLocale);
+
+/**
+ * Report-renderer-specific strings.
+ * @type {LH.I18NRendererStrings}
+ */
+Util.UIStrings = {
+  /** Disclaimer shown to users below the metric values (First Contentful Paint, Time to Interactive, etc) to warn them that the numbers they see will likely change slightly the next time they run Lighthouse. */
+  varianceDisclaimer: 'Values are estimated and may vary. The performance score is [based only on these metrics](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted).',
+  /** Column heading label for the listing of opportunity audits. Each audit title represents an opportunity. There are only 2 columns, so no strict character limit.  */
+  opportunityResourceColumnLabel: 'Opportunity',
+  /** Column heading label for the estimated page load savings of opportunity audits. Estimated Savings is the total amount of time (in seconds) that Lighthouse computed could be reduced from the total page load time, if the suggested action is taken. There are only 2 columns, so no strict character limit. */
+  opportunitySavingsColumnLabel: 'Estimated Savings',
+
+  /** An error string displayed next to a particular audit when it has errored, but not provided any specific error message. */
+  errorMissingAuditInfo: 'Report error: no audit information',
+  /** A label, shown next to an audit title or metric title, indicating that there was an error computing it. The user can hover on the label to reveal a tooltip with the extended error message. Translation should be short (< 20 characters). */
+  errorLabel: 'Error!',
+  /** This label is shown above a bulleted list of warnings. It is shown directly below an audit that produced warnings. Warnings describe situations the user should be aware of, as Lighthouse was unable to complete all the work required on this audit. For example, The 'Unable to decode image (biglogo.jpg)' warning may show up below an image encoding audit. */
+  warningHeader: 'Warnings: ',
+  /** The tooltip text on an expandable chevron icon. Clicking the icon expands a section to reveal a list of audit results that was hidden by default. */
+  auditGroupExpandTooltip: 'Show audits',
+  /** Section heading shown above a list of passed audits that contain warnings. Audits under this section do not negatively impact the score, but Lighthouse has generated some potentially actionable suggestions that should be reviewed. This section is expanded by default and displays after the failing audits. */
+  warningAuditsGroupTitle: 'Passed audits but with warnings',
+  /** Section heading shown above a list of audits that are passing. 'Passed' here refers to a passing grade. This section is collapsed by default, as the user should be focusing on the failed audits instead. Users can click this heading to reveal the list. */
+  passedAuditsGroupTitle: 'Passed audits',
+  /** Section heading shown above a list of audits that do not apply to the page. For example, if an audit is 'Are images optimized?', but the page has no images on it, the audit will be marked as not applicable. This is neither passing or failing. This section is collapsed by default, as the user should be focusing on the failed audits instead. Users can click this heading to reveal the list. */
+  notApplicableAuditsGroupTitle: 'Not applicable',
+  /** Section heading shown above a list of audits that were not computed by Lighthouse. They serve as a list of suggestions for the user to go and manually check. For example, Lighthouse can't automate testing cross-browser compatibility, so that is listed within this section, so the user is reminded to test it themselves. This section is collapsed by default, as the user should be focusing on the failed audits instead. Users can click this heading to reveal the list. */
+  manualAuditsGroupTitle: 'Additional items to manually check',
+
+  /** Label shown preceding any important warnings that may have invalidated the entire report. For example, if the user has Chrome extensions installed, they may add enough performance overhead that Lighthouse's performance metrics are unreliable. If shown, this will be displayed at the top of the report UI. */
+  toplevelWarningsMessage: 'There were issues affecting this run of Lighthouse:',
+
+  /** String of text shown in a graphical representation of the flow of network requests for the web page. This label represents the initial network request that fetches an HTML page. This navigation may be redirected (eg. Initial navigation to http://example.com redirects to https://www.example.com). */
+  crcInitialNavigation: 'Initial Navigation',
+  /** Label of value shown in the summary of critical request chains. Refers to the total amount of time (milliseconds) of the longest critical path chain/sequence of network requests. Example value: 2310 ms */
+  crcLongestDurationLabel: 'Maximum critical path latency:',
+
+  /** Label for button that shows all lines of the snippet when clicked */
+  snippetExpandButtonLabel: 'Expand snippet',
+  /** Label for button that only shows a few lines of the snippet when clicked */
+  snippetCollapseButtonLabel: 'Collapse snippet',
+
+  /** Explanation shown to users below performance results to inform them that the test was done with a 4G network connection and to warn them that the numbers they see will likely change slightly the next time they run Lighthouse. 'Lighthouse' becomes link text to additional documentation. */
+  lsPerformanceCategoryDescription: '[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.',
+  /** Title of the lab data section of the Performance category. Within this section are various speed metrics which quantify the pageload performance into values presented in seconds and milliseconds. "Lab" is an abbreviated form of "laboratory", and refers to the fact that the data is from a controlled test of a website, not measurements from real users visiting that site.  */
+  labDataTitle: 'Lab Data',
+
+  /** This label is for a checkbox above a table of items loaded by a web page. The checkbox is used to show or hide third-party (or "3rd-party") resources in the table, where "third-party resources" refers to items loaded by a web page from URLs that aren't controlled by the owner of the web page. */
+  thirdPartyResourcesLabel: 'Show 3rd-party resources',
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = Util;
+} else {
+  self.Util = Util;
+}
+;
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* globals URL self Util */
+
+/** @typedef {HTMLElementTagNameMap & {[id: string]: HTMLElement}} HTMLElementByTagName */
+
+class DOM {
+  /**
+   * @param {Document} document
+   */
+  constructor(document) {
+    /** @type {Document} */
+    this._document = document;
+    /** @type {string} */
+    this._lighthouseChannel = 'unknown';
+  }
+
+  /**
+   * @template {string} T
+   * @param {T} name
+   * @param {string=} className
+   * @param {Object<string, (string|undefined)>=} attrs Attribute key/val pairs.
+   *     Note: if an attribute key has an undefined value, this method does not
+   *     set the attribute on the node.
+   * @return {HTMLElementByTagName[T]}
+   */
+  createElement(name, className, attrs = {}) {
+    const element = this._document.createElement(name);
+    if (className) {
+      element.className = className;
+    }
+    Object.keys(attrs).forEach(key => {
+      const value = attrs[key];
+      if (typeof value !== 'undefined') {
+        element.setAttribute(key, value);
+      }
+    });
+    return element;
+  }
+
+  /**
+   * @return {DocumentFragment}
+   */
+  createFragment() {
+    return this._document.createDocumentFragment();
+  }
+
+  /**
+   * @template {string} T
+   * @param {Element} parentElem
+   * @param {T} elementName
+   * @param {string=} className
+   * @param {Object<string, (string|undefined)>=} attrs Attribute key/val pairs.
+   *     Note: if an attribute key has an undefined value, this method does not
+   *     set the attribute on the node.
+   * @return {HTMLElementByTagName[T]}
+   */
+  createChildOf(parentElem, elementName, className, attrs) {
+    const element = this.createElement(elementName, className, attrs);
+    parentElem.appendChild(element);
+    return element;
+  }
+
+  /**
+   * @param {string} selector
+   * @param {ParentNode} context
+   * @return {DocumentFragment} A clone of the template content.
+   * @throws {Error}
+   */
+  cloneTemplate(selector, context) {
+    const template = /** @type {?HTMLTemplateElement} */ (context.querySelector(selector));
+    if (!template) {
+      throw new Error(`Template not found: template${selector}`);
+    }
+
+    const clone = this._document.importNode(template.content, true);
+
+    // Prevent duplicate styles in the DOM. After a template has been stamped
+    // for the first time, remove the clone's styles so they're not re-added.
+    if (template.hasAttribute('data-stamped')) {
+      this.findAll('style', clone).forEach(style => style.remove());
+    }
+    template.setAttribute('data-stamped', 'true');
+
+    return clone;
+  }
+
+  /**
+   * Resets the "stamped" state of the templates.
+   */
+  resetTemplates() {
+    this.findAll('template[data-stamped]', this._document).forEach(t => {
+      t.removeAttribute('data-stamped');
+    });
+  }
+
+  /**
+   * @param {string} text
+   * @return {Element}
+   */
+  convertMarkdownLinkSnippets(text) {
+    const element = this.createElement('span');
+
+    for (const segment of Util.splitMarkdownLink(text)) {
+      if (!segment.isLink) {
+        // Plain text segment.
+        element.appendChild(this._document.createTextNode(segment.text));
+        continue;
+      }
+
+      // Otherwise, append any links found.
+      const url = new URL(segment.linkHref);
+
+      const DOCS_ORIGINS = ['https://developers.google.com', 'https://web.dev'];
+      if (DOCS_ORIGINS.includes(url.origin)) {
+        url.searchParams.set('utm_source', 'lighthouse');
+        url.searchParams.set('utm_medium', this._lighthouseChannel);
+      }
+
+      const a = this.createElement('a');
+      a.rel = 'noopener';
+      a.target = '_blank';
+      a.textContent = segment.text;
+      a.href = url.href;
+      element.appendChild(a);
+    }
+
+    return element;
+  }
+
+  /**
+   * @param {string} markdownText
+   * @return {Element}
+   */
+  convertMarkdownCodeSnippets(markdownText) {
+    const element = this.createElement('span');
+
+    for (const segment of Util.splitMarkdownCodeSpans(markdownText)) {
+      if (segment.isCode) {
+        const pre = this.createElement('code');
+        pre.textContent = segment.text;
+        element.appendChild(pre);
+      } else {
+        element.appendChild(this._document.createTextNode(segment.text));
+      }
+    }
+
+    return element;
+  }
+
+  /**
+   * The channel to use for UTM data when rendering links to the documentation.
+   * @param {string} lighthouseChannel
+   */
+  setLighthouseChannel(lighthouseChannel) {
+    this._lighthouseChannel = lighthouseChannel;
+  }
+
+  /**
+   * @return {Document}
+   */
+  document() {
+    return this._document;
+  }
+
+  /**
+   * TODO(paulirish): import and conditionally apply the DevTools frontend subclasses instead of this
+   * @return {boolean}
+   */
+  isDevTools() {
+    return !!this._document.querySelector('.lh-devtools');
+  }
+
+  /**
+   * Guaranteed context.querySelector. Always returns an element or throws if
+   * nothing matches query.
+   * @param {string} query
+   * @param {ParentNode} context
+   * @return {HTMLElement}
+   */
+  find(query, context) {
+    /** @type {?HTMLElement} */
+    const result = context.querySelector(query);
+    if (result === null) {
+      throw new Error(`query ${query} not found`);
+    }
+    return result;
+  }
+
+  /**
+   * Helper for context.querySelectorAll. Returns an Array instead of a NodeList.
+   * @param {string} query
+   * @param {ParentNode} context
+   * @return {Array<HTMLElement>}
+   */
+  findAll(query, context) {
+    return Array.from(context.querySelectorAll(query));
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = DOM;
+} else {
+  self.DOM = DOM;
+}
+;
+/*
+Details Element Polyfill 2.4.0
+Copyright © 2019 Javan Makhmali
+ */
+(function() {
+  "use strict";
+  var element = document.createElement("details");
+  var elementIsNative = typeof HTMLDetailsElement != "undefined" && element instanceof HTMLDetailsElement;
+  var support = {
+    open: "open" in element || elementIsNative,
+    toggle: "ontoggle" in element
+  };
+  var styles = '\ndetails, summary {\n  display: block;\n}\ndetails:not([open]) > *:not(summary) {\n  display: none;\n}\nsummary::before {\n  content: "►";\n  padding-right: 0.3rem;\n  font-size: 0.6rem;\n  cursor: default;\n}\n[open] > summary::before {\n  content: "▼";\n}\n';
+  var _ref = [], forEach = _ref.forEach, slice = _ref.slice;
+  if (!support.open) {
+    polyfillStyles();
+    polyfillProperties();
+    polyfillToggle();
+    polyfillAccessibility();
+  }
+  if (support.open && !support.toggle) {
+    polyfillToggleEvent();
+  }
+  function polyfillStyles() {
+    document.head.insertAdjacentHTML("afterbegin", "<style>" + styles + "\u003c/style>");
+  }
+  function polyfillProperties() {
+    var prototype = document.createElement("details").constructor.prototype;
+    var setAttribute = prototype.setAttribute, removeAttribute = prototype.removeAttribute;
+    var open = Object.getOwnPropertyDescriptor(prototype, "open");
+    Object.defineProperties(prototype, {
+      open: {
+        get: function get() {
+          if (this.tagName == "DETAILS") {
+            return this.hasAttribute("open");
+          } else {
+            if (open && open.get) {
+              return open.get.call(this);
+            }
+          }
+        },
+        set: function set(value) {
+          if (this.tagName == "DETAILS") {
+            return value ? this.setAttribute("open", "") : this.removeAttribute("open");
+          } else {
+            if (open && open.set) {
+              return open.set.call(this, value);
+            }
+          }
+        }
+      },
+      setAttribute: {
+        value: function value(name, _value) {
+          var _this = this;
+          var call = function call() {
+            return setAttribute.call(_this, name, _value);
+          };
+          if (name == "open" && this.tagName == "DETAILS") {
+            var wasOpen = this.hasAttribute("open");
+            var result = call();
+            if (!wasOpen) {
+              var summary = this.querySelector("summary");
+              if (summary) summary.setAttribute("aria-expanded", true);
+              triggerToggle(this);
+            }
+            return result;
+          }
+          return call();
+        }
+      },
+      removeAttribute: {
+        value: function value(name) {
+          var _this2 = this;
+          var call = function call() {
+            return removeAttribute.call(_this2, name);
+          };
+          if (name == "open" && this.tagName == "DETAILS") {
+            var wasOpen = this.hasAttribute("open");
+            var result = call();
+            if (wasOpen) {
+              var summary = this.querySelector("summary");
+              if (summary) summary.setAttribute("aria-expanded", false);
+              triggerToggle(this);
+            }
+            return result;
+          }
+          return call();
+        }
+      }
+    });
+  }
+  function polyfillToggle() {
+    onTogglingTrigger(function(element) {
+      element.hasAttribute("open") ? element.removeAttribute("open") : element.setAttribute("open", "");
+    });
+  }
+  function polyfillToggleEvent() {
+    if (window.MutationObserver) {
+      new MutationObserver(function(mutations) {
+        forEach.call(mutations, function(mutation) {
+          var target = mutation.target, attributeName = mutation.attributeName;
+          if (target.tagName == "DETAILS" && attributeName == "open") {
+            triggerToggle(target);
+          }
+        });
+      }).observe(document.documentElement, {
+        attributes: true,
+        subtree: true
+      });
+    } else {
+      onTogglingTrigger(function(element) {
+        var wasOpen = element.getAttribute("open");
+        setTimeout(function() {
+          var isOpen = element.getAttribute("open");
+          if (wasOpen != isOpen) {
+            triggerToggle(element);
+          }
+        }, 1);
+      });
+    }
+  }
+  function polyfillAccessibility() {
+    setAccessibilityAttributes(document);
+    if (window.MutationObserver) {
+      new MutationObserver(function(mutations) {
+        forEach.call(mutations, function(mutation) {
+          forEach.call(mutation.addedNodes, setAccessibilityAttributes);
+        });
+      }).observe(document.documentElement, {
+        subtree: true,
+        childList: true
+      });
+    } else {
+      document.addEventListener("DOMNodeInserted", function(event) {
+        setAccessibilityAttributes(event.target);
+      });
+    }
+  }
+  function setAccessibilityAttributes(root) {
+    findElementsWithTagName(root, "SUMMARY").forEach(function(summary) {
+      var details = findClosestElementWithTagName(summary, "DETAILS");
+      summary.setAttribute("aria-expanded", details.hasAttribute("open"));
+      if (!summary.hasAttribute("tabindex")) summary.setAttribute("tabindex", "0");
+      if (!summary.hasAttribute("role")) summary.setAttribute("role", "button");
+    });
+  }
+  function eventIsSignificant(event) {
+    return !(event.defaultPrevented || event.ctrlKey || event.metaKey || event.shiftKey || event.target.isContentEditable);
+  }
+  function onTogglingTrigger(callback) {
+    addEventListener("click", function(event) {
+      if (eventIsSignificant(event)) {
+        if (event.which <= 1) {
+          var element = findClosestElementWithTagName(event.target, "SUMMARY");
+          if (element && element.parentNode && element.parentNode.tagName == "DETAILS") {
+            callback(element.parentNode);
+          }
+        }
+      }
+    }, false);
+    addEventListener("keydown", function(event) {
+      if (eventIsSignificant(event)) {
+        if (event.keyCode == 13 || event.keyCode == 32) {
+          var element = findClosestElementWithTagName(event.target, "SUMMARY");
+          if (element && element.parentNode && element.parentNode.tagName == "DETAILS") {
+            callback(element.parentNode);
+            event.preventDefault();
+          }
+        }
+      }
+    }, false);
+  }
+  function triggerToggle(element) {
+    var event = document.createEvent("Event");
+    event.initEvent("toggle", false, false);
+    element.dispatchEvent(event);
+  }
+  function findElementsWithTagName(root, tagName) {
+    return (root.tagName == tagName ? [ root ] : []).concat(typeof root.getElementsByTagName == "function" ? slice.call(root.getElementsByTagName(tagName)) : []);
+  }
+  function findClosestElementWithTagName(element, tagName) {
+    if (typeof element.closest == "function") {
+      return element.closest(tagName);
+    } else {
+      while (element) {
+        if (element.tagName == tagName) {
+          return element;
+        } else {
+          element = element.parentNode;
+        }
+      }
+    }
+  }
+})();
+;
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* globals self CriticalRequestChainRenderer SnippetRenderer Util URL */
+
+/** @typedef {import('./dom.js')} DOM */
+
+const URL_PREFIXES = ['http://', 'https://', 'data:'];
+
+class DetailsRenderer {
+  /**
+   * @param {DOM} dom
+   */
+  constructor(dom) {
+    /** @type {DOM} */
+    this._dom = dom;
+    /** @type {ParentNode} */
+    this._templateContext; // eslint-disable-line no-unused-expressions
+  }
+
+  /**
+   * @param {ParentNode} context
+   */
+  setTemplateContext(context) {
+    this._templateContext = context;
+  }
+
+  /**
+   * @param {LH.Audit.Details} details
+   * @return {Element|null}
+   */
+  render(details) {
+    switch (details.type) {
+      case 'filmstrip':
+        return this._renderFilmstrip(details);
+      case 'list':
+        return this._renderList(details);
+      case 'table':
+        return this._renderTable(details);
+      case 'criticalrequestchain':
+        return CriticalRequestChainRenderer.render(this._dom, this._templateContext, details, this);
+      case 'opportunity':
+        return this._renderTable(details);
+
+      // Internal-only details, not for rendering.
+      case 'screenshot':
+      case 'debugdata':
+        return null;
+
+      default: {
+        // @ts-ignore tsc thinks this is unreachable, but be forward compatible
+        // with new unexpected detail types.
+        return this._renderUnknown(details.type, details);
+      }
+    }
+  }
+
+  /**
+   * @param {{value: number, granularity?: number}} details
+   * @return {Element}
+   */
+  _renderBytes(details) {
+    // TODO: handle displayUnit once we have something other than 'kb'
+    const value = Util.formatBytesToKB(details.value, details.granularity);
+    return this._renderText(value);
+  }
+
+  /**
+   * @param {{value: number, granularity?: number, displayUnit?: string}} details
+   * @return {Element}
+   */
+  _renderMilliseconds(details) {
+    let value = Util.formatMilliseconds(details.value, details.granularity);
+    if (details.displayUnit === 'duration') {
+      value = Util.formatDuration(details.value);
+    }
+
+    return this._renderText(value);
+  }
+
+  /**
+   * @param {string} text
+   * @return {HTMLElement}
+   */
+  renderTextURL(text) {
+    const url = text;
+
+    let displayedPath;
+    let displayedHost;
+    let title;
+    try {
+      const parsed = Util.parseURL(url);
+      displayedPath = parsed.file === '/' ? parsed.origin : parsed.file;
+      displayedHost = parsed.file === '/' ? '' : `(${parsed.hostname})`;
+      title = url;
+    } catch (e) {
+      displayedPath = url;
+    }
+
+    const element = this._dom.createElement('div', 'lh-text__url');
+    element.appendChild(this._renderLink({text: displayedPath, url}));
+
+    if (displayedHost) {
+      const hostElem = this._renderText(displayedHost);
+      hostElem.classList.add('lh-text__url-host');
+      element.appendChild(hostElem);
+    }
+
+    if (title) {
+      element.title = url;
+      // set the url on the element's dataset which we use to check 3rd party origins
+      element.dataset.url = url;
+    }
+    return element;
+  }
+
+  /**
+   * @param {{text: string, url: string}} details
+   * @return {Element}
+   */
+  _renderLink(details) {
+    const allowedProtocols = ['https:', 'http:'];
+    let url;
+    try {
+      url = new URL(details.url);
+    } catch (_) {}
+
+    if (!url || !allowedProtocols.includes(url.protocol)) {
+      // Fall back to just the link text if invalid or protocol not allowed.
+      return this._renderText(details.text);
+    }
+
+    const a = this._dom.createElement('a');
+    a.rel = 'noopener';
+    a.target = '_blank';
+    a.textContent = details.text;
+    a.href = url.href;
+
+    return a;
+  }
+
+  /**
+   * @param {string} text
+   * @return {Element}
+   */
+  _renderText(text) {
+    const element = this._dom.createElement('div', 'lh-text');
+    element.textContent = text;
+    return element;
+  }
+
+  /**
+   * @param {string} text
+   * @return {Element}
+   */
+  _renderNumeric(text) {
+    const element = this._dom.createElement('div', 'lh-numeric');
+    element.textContent = text;
+    return element;
+  }
+
+  /**
+   * Create small thumbnail with scaled down image asset.
+   * @param {string} details
+   * @return {Element}
+   */
+  _renderThumbnail(details) {
+    const element = this._dom.createElement('img', 'lh-thumbnail');
+    const strValue = details;
+    element.src = strValue;
+    element.title = strValue;
+    element.alt = '';
+    return element;
+  }
+
+  /**
+   * @param {string} type
+   * @param {*} value
+   */
+  _renderUnknown(type, value) {
+    // eslint-disable-next-line no-console
+    console.error(`Unknown details type: ${type}`, value);
+    const element = this._dom.createElement('details', 'lh-unknown');
+    this._dom.createChildOf(element, 'summary').textContent =
+      `We don't know how to render audit details of type \`${type}\`. ` +
+      'The Lighthouse version that collected this data is likely newer than the Lighthouse ' +
+      'version of the report renderer. Expand for the raw JSON.';
+    this._dom.createChildOf(element, 'pre').textContent = JSON.stringify(value, null, 2);
+    return element;
+  }
+
+  /**
+   * Render a details item value for embedding in a table. Renders the value
+   * based on the heading's valueType, unless the value itself has a `type`
+   * property to override it.
+   * @param {LH.Audit.Details.TableItem[string] | LH.Audit.Details.OpportunityItem[string]} value
+   * @param {LH.Audit.Details.OpportunityColumnHeading} heading
+   * @return {Element|null}
+   */
+  _renderTableValue(value, heading) {
+    if (typeof value === 'undefined' || value === null) {
+      return null;
+    }
+
+    // First deal with the possible object forms of value.
+    if (typeof value === 'object') {
+      // The value's type overrides the heading's for this column.
+      switch (value.type) {
+        case 'code': {
+          return this._renderCode(value.value);
+        }
+        case 'link': {
+          return this._renderLink(value);
+        }
+        case 'node': {
+          return this.renderNode(value);
+        }
+        case 'url': {
+          return this.renderTextURL(value.value);
+        }
+        default: {
+          return this._renderUnknown(value.type, value);
+        }
+      }
+    }
+
+    // Next, deal with primitives.
+    switch (heading.valueType) {
+      case 'bytes': {
+        const numValue = Number(value);
+        return this._renderBytes({value: numValue, granularity: 1});
+      }
+      case 'code': {
+        const strValue = String(value);
+        return this._renderCode(strValue);
+      }
+      case 'ms': {
+        const msValue = {
+          value: Number(value),
+          granularity: heading.granularity,
+          displayUnit: heading.displayUnit,
+        };
+        return this._renderMilliseconds(msValue);
+      }
+      case 'numeric': {
+        const strValue = String(value);
+        return this._renderNumeric(strValue);
+      }
+      case 'text': {
+        const strValue = String(value);
+        return this._renderText(strValue);
+      }
+      case 'thumbnail': {
+        const strValue = String(value);
+        return this._renderThumbnail(strValue);
+      }
+      case 'timespanMs': {
+        const numValue = Number(value);
+        return this._renderMilliseconds({value: numValue});
+      }
+      case 'url': {
+        const strValue = String(value);
+        if (URL_PREFIXES.some(prefix => strValue.startsWith(prefix))) {
+          return this.renderTextURL(strValue);
+        } else {
+          // Fall back to <pre> rendering if not actually a URL.
+          return this._renderCode(strValue);
+        }
+      }
+      default: {
+        return this._renderUnknown(heading.valueType, value);
+      }
+    }
+  }
+
+  /**
+   * Get the headings of a table-like details object, converted into the
+   * OpportunityColumnHeading type until we have all details use the same
+   * heading format.
+   * @param {LH.Audit.Details.Table|LH.Audit.Details.Opportunity} tableLike
+   * @return {Array<LH.Audit.Details.OpportunityColumnHeading>} header
+   */
+  _getCanonicalizedTableHeadings(tableLike) {
+    if (tableLike.type === 'opportunity') {
+      return tableLike.headings;
+    }
+
+    return tableLike.headings.map(heading => {
+      return {
+        key: heading.key,
+        label: heading.text,
+        valueType: heading.itemType,
+        displayUnit: heading.displayUnit,
+        granularity: heading.granularity,
+      };
+    });
+  }
+
+  /**
+   * @param {LH.Audit.Details.Table|LH.Audit.Details.Opportunity} details
+   * @return {Element}
+   */
+  _renderTable(details) {
+    if (!details.items.length) return this._dom.createElement('span');
+
+    const tableElem = this._dom.createElement('table', 'lh-table');
+    const theadElem = this._dom.createChildOf(tableElem, 'thead');
+    const theadTrElem = this._dom.createChildOf(theadElem, 'tr');
+
+    const headings = this._getCanonicalizedTableHeadings(details);
+
+    for (const heading of headings) {
+      const valueType = heading.valueType || 'text';
+      const classes = `lh-table-column--${valueType}`;
+      const labelEl = this._dom.createElement('div', 'lh-text');
+      labelEl.textContent = heading.label;
+      this._dom.createChildOf(theadTrElem, 'th', classes).appendChild(labelEl);
+    }
+
+    const tbodyElem = this._dom.createChildOf(tableElem, 'tbody');
+    for (const row of details.items) {
+      const rowElem = this._dom.createChildOf(tbodyElem, 'tr');
+      for (const heading of headings) {
+        const value = row[heading.key];
+        const valueElement = this._renderTableValue(value, heading);
+
+        if (valueElement) {
+          const classes = `lh-table-column--${heading.valueType}`;
+          this._dom.createChildOf(rowElem, 'td', classes).appendChild(valueElement);
+        } else {
+          this._dom.createChildOf(rowElem, 'td', 'lh-table-column--empty');
+        }
+      }
+    }
+    return tableElem;
+  }
+
+  /**
+   * @param {LH.Audit.Details.List} details
+   * @return {Element}
+   */
+  _renderList(details) {
+    const listContainer = this._dom.createElement('div', 'lh-list');
+
+    details.items.forEach(item => {
+      const snippetEl = SnippetRenderer.render(this._dom, this._templateContext, item, this);
+      listContainer.appendChild(snippetEl);
+    });
+
+    return listContainer;
+  }
+
+  /**
+   * @param {LH.Audit.Details.NodeValue} item
+   * @return {Element}
+   * @protected
+   */
+  renderNode(item) {
+    const element = this._dom.createElement('span', 'lh-node');
+    if (item.nodeLabel) {
+      const nodeLabelEl = this._dom.createElement('div');
+      nodeLabelEl.textContent = item.nodeLabel;
+      element.appendChild(nodeLabelEl);
+    }
+    if (item.snippet) {
+      const snippetEl = this._dom.createElement('div');
+      snippetEl.classList.add('lh-node__snippet');
+      snippetEl.textContent = item.snippet;
+      element.appendChild(snippetEl);
+    }
+    if (item.selector) {
+      element.title = item.selector;
+    }
+    if (item.path) element.setAttribute('data-path', item.path);
+    if (item.selector) element.setAttribute('data-selector', item.selector);
+    if (item.snippet) element.setAttribute('data-snippet', item.snippet);
+
+    return element;
+  }
+
+  /**
+   * @param {LH.Audit.Details.Filmstrip} details
+   * @return {Element}
+   */
+  _renderFilmstrip(details) {
+    const filmstripEl = this._dom.createElement('div', 'lh-filmstrip');
+
+    for (const thumbnail of details.items) {
+      const frameEl = this._dom.createChildOf(filmstripEl, 'div', 'lh-filmstrip__frame');
+      this._dom.createChildOf(frameEl, 'img', 'lh-filmstrip__thumbnail', {
+        src: thumbnail.data,
+        alt: `Screenshot`,
+      });
+    }
+    return filmstripEl;
+  }
+
+  /**
+   * @param {string} text
+   * @return {Element}
+   */
+  _renderCode(text) {
+    const pre = this._dom.createElement('pre', 'lh-code');
+    pre.textContent = text;
+    return pre;
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = DetailsRenderer;
+} else {
+  self.DetailsRenderer = DetailsRenderer;
+}
+;
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview This file contains helpers for constructing and rendering the
+ * critical request chains network tree.
+ */
+
+/* globals self Util */
+
+/** @typedef {import('./dom.js')} DOM */
+
+class CriticalRequestChainRenderer {
+  /**
+   * Create render context for critical-request-chain tree display.
+   * @param {LH.Audit.SimpleCriticalRequestNode} tree
+   * @return {{tree: LH.Audit.SimpleCriticalRequestNode, startTime: number, transferSize: number}}
+   */
+  static initTree(tree) {
+    let startTime = 0;
+    const rootNodes = Object.keys(tree);
+    if (rootNodes.length > 0) {
+      const node = tree[rootNodes[0]];
+      startTime = node.request.startTime;
+    }
+
+    return {tree, startTime, transferSize: 0};
+  }
+
+  /**
+   * Helper to create context for each critical-request-chain node based on its
+   * parent. Calculates if this node is the last child, whether it has any
+   * children itself and what the tree looks like all the way back up to the root,
+   * so the tree markers can be drawn correctly.
+   * @param {LH.Audit.SimpleCriticalRequestNode} parent
+   * @param {string} id
+   * @param {number} startTime
+   * @param {number} transferSize
+   * @param {Array<boolean>=} treeMarkers
+   * @param {boolean=} parentIsLastChild
+   * @return {CRCSegment}
+   */
+  static createSegment(parent, id, startTime, transferSize, treeMarkers, parentIsLastChild) {
+    const node = parent[id];
+    const siblings = Object.keys(parent);
+    const isLastChild = siblings.indexOf(id) === (siblings.length - 1);
+    const hasChildren = !!node.children && Object.keys(node.children).length > 0;
+
+    // Copy the tree markers so that we don't change by reference.
+    const newTreeMarkers = Array.isArray(treeMarkers) ? treeMarkers.slice(0) : [];
+
+    // Add on the new entry.
+    if (typeof parentIsLastChild !== 'undefined') {
+      newTreeMarkers.push(!parentIsLastChild);
+    }
+
+    return {
+      node,
+      isLastChild,
+      hasChildren,
+      startTime,
+      transferSize: transferSize + node.request.transferSize,
+      treeMarkers: newTreeMarkers,
+    };
+  }
+
+  /**
+   * Creates the DOM for a tree segment.
+   * @param {DOM} dom
+   * @param {DocumentFragment} tmpl
+   * @param {CRCSegment} segment
+   * @param {DetailsRenderer} detailsRenderer
+   * @return {Node}
+   */
+  static createChainNode(dom, tmpl, segment, detailsRenderer) {
+    const chainsEl = dom.cloneTemplate('#tmpl-lh-crc__chains', tmpl);
+
+    // Hovering over request shows full URL.
+    dom.find('.crc-node', chainsEl).setAttribute('title', segment.node.request.url);
+
+    const treeMarkeEl = dom.find('.crc-node__tree-marker', chainsEl);
+
+    // Construct lines and add spacers for sub requests.
+    segment.treeMarkers.forEach(separator => {
+      if (separator) {
+        treeMarkeEl.appendChild(dom.createElement('span', 'tree-marker vert'));
+        treeMarkeEl.appendChild(dom.createElement('span', 'tree-marker'));
+      } else {
+        treeMarkeEl.appendChild(dom.createElement('span', 'tree-marker'));
+        treeMarkeEl.appendChild(dom.createElement('span', 'tree-marker'));
+      }
+    });
+
+    if (segment.isLastChild) {
+      treeMarkeEl.appendChild(dom.createElement('span', 'tree-marker up-right'));
+      treeMarkeEl.appendChild(dom.createElement('span', 'tree-marker right'));
+    } else {
+      treeMarkeEl.appendChild(dom.createElement('span', 'tree-marker vert-right'));
+      treeMarkeEl.appendChild(dom.createElement('span', 'tree-marker right'));
+    }
+
+    if (segment.hasChildren) {
+      treeMarkeEl.appendChild(dom.createElement('span', 'tree-marker horiz-down'));
+    } else {
+      treeMarkeEl.appendChild(dom.createElement('span', 'tree-marker right'));
+    }
+
+    // Fill in url, host, and request size information.
+    const url = segment.node.request.url;
+    const linkEl = detailsRenderer.renderTextURL(url);
+    const treevalEl = dom.find('.crc-node__tree-value', chainsEl);
+    treevalEl.appendChild(linkEl);
+
+    if (!segment.hasChildren) {
+      const {startTime, endTime, transferSize} = segment.node.request;
+      const span = dom.createElement('span', 'crc-node__chain-duration');
+      span.textContent = ' - ' + Util.formatMilliseconds((endTime - startTime) * 1000) + ', ';
+      const span2 = dom.createElement('span', 'crc-node__chain-duration');
+      span2.textContent = Util.formatBytesToKB(transferSize, 0.01);
+
+      treevalEl.appendChild(span);
+      treevalEl.appendChild(span2);
+    }
+
+    return chainsEl;
+  }
+
+  /**
+   * Recursively builds a tree from segments.
+   * @param {DOM} dom
+   * @param {DocumentFragment} tmpl
+   * @param {CRCSegment} segment
+   * @param {Element} elem Parent element.
+   * @param {LH.Audit.Details.CriticalRequestChain} details
+   * @param {DetailsRenderer} detailsRenderer
+   */
+  static buildTree(dom, tmpl, segment, elem, details, detailsRenderer) {
+    elem.appendChild(CRCRenderer.createChainNode(dom, tmpl, segment, detailsRenderer));
+    if (segment.node.children) {
+      for (const key of Object.keys(segment.node.children)) {
+        const childSegment = CRCRenderer.createSegment(segment.node.children, key,
+          segment.startTime, segment.transferSize, segment.treeMarkers, segment.isLastChild);
+        CRCRenderer.buildTree(dom, tmpl, childSegment, elem, details, detailsRenderer);
+      }
+    }
+  }
+
+  /**
+   * @param {DOM} dom
+   * @param {ParentNode} templateContext
+   * @param {LH.Audit.Details.CriticalRequestChain} details
+   * @param {DetailsRenderer} detailsRenderer
+   * @return {Element}
+   */
+  static render(dom, templateContext, details, detailsRenderer) {
+    const tmpl = dom.cloneTemplate('#tmpl-lh-crc', templateContext);
+    const containerEl = dom.find('.lh-crc', tmpl);
+
+    // Fill in top summary.
+    dom.find('.crc-initial-nav', tmpl).textContent = Util.UIStrings.crcInitialNavigation;
+    dom.find('.lh-crc__longest_duration_label', tmpl).textContent =
+        Util.UIStrings.crcLongestDurationLabel;
+    dom.find('.lh-crc__longest_duration', tmpl).textContent =
+        Util.formatMilliseconds(details.longestChain.duration);
+
+    // Construct visual tree.
+    const root = CRCRenderer.initTree(details.chains);
+    for (const key of Object.keys(root.tree)) {
+      const segment = CRCRenderer.createSegment(root.tree, key, root.startTime, root.transferSize);
+      CRCRenderer.buildTree(dom, tmpl, segment, containerEl, details, detailsRenderer);
+    }
+
+    return dom.find('.lh-crc-container', tmpl);
+  }
+}
+
+// Alias b/c the name is really long.
+const CRCRenderer = CriticalRequestChainRenderer;
+
+// Allow Node require()'ing.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = CriticalRequestChainRenderer;
+} else {
+  self.CriticalRequestChainRenderer = CriticalRequestChainRenderer;
+}
+
+/** @typedef {{
+      node: LH.Audit.SimpleCriticalRequestNode[string],
+      isLastChild: boolean,
+      hasChildren: boolean,
+      startTime: number,
+      transferSize: number,
+      treeMarkers: Array<boolean>
+  }} CRCSegment
+ */
+;
+/**
+ * @license Copyright 2019 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* globals self, Util */
+
+/** @typedef {import('./details-renderer')} DetailsRenderer */
+
+/** @enum {number} */
+const LineVisibility = {
+  /** Show regardless of whether the snippet is collapsed or expanded */
+  ALWAYS: 0,
+  WHEN_COLLAPSED: 1,
+  WHEN_EXPANDED: 2,
+};
+
+/** @enum {number} */
+const LineContentType = {
+  /** A line of content */
+  CONTENT_NORMAL: 0,
+  /** A line of content that's emphasized by setting the CSS background color */
+  CONTENT_HIGHLIGHTED: 1,
+  /** Use when some lines are hidden, shows the "..." placeholder */
+  PLACEHOLDER: 2,
+  /** A message about a line of content or the snippet in general */
+  MESSAGE: 3,
+};
+
+/** @typedef {{
+    content: string;
+    lineNumber: string | number;
+    contentType: LineContentType;
+    truncated?: boolean;
+    visibility?: LineVisibility;
+}} LineDetails */
+
+const classNamesByContentType = {
+  [LineContentType.CONTENT_NORMAL]: ['lh-snippet__line--content'],
+  [LineContentType.CONTENT_HIGHLIGHTED]: [
+    'lh-snippet__line--content',
+    'lh-snippet__line--content-highlighted',
+  ],
+  [LineContentType.PLACEHOLDER]: ['lh-snippet__line--placeholder'],
+  [LineContentType.MESSAGE]: ['lh-snippet__line--message'],
+};
+
+/**
+ * @param {LH.Audit.Details.SnippetValue['lines']} lines
+ * @param {number} lineNumber
+ * @return {{line?: LH.Audit.Details.SnippetValue['lines'][0], previousLine?: LH.Audit.Details.SnippetValue['lines'][0]}}
+ */
+function getLineAndPreviousLine(lines, lineNumber) {
+  return {
+    line: lines.find(l => l.lineNumber === lineNumber),
+    previousLine: lines.find(l => l.lineNumber === lineNumber - 1),
+  };
+}
+
+/**
+ * @param {LH.Audit.Details.SnippetValue["lineMessages"]} messages
+ * @param {number} lineNumber
+ */
+function getMessagesForLineNumber(messages, lineNumber) {
+  return messages.filter(h => h.lineNumber === lineNumber);
+}
+
+/**
+ * @param {LH.Audit.Details.SnippetValue} details
+ * @return {LH.Audit.Details.SnippetValue['lines']}
+ */
+function getLinesWhenCollapsed(details) {
+  const SURROUNDING_LINES_TO_SHOW_WHEN_COLLAPSED = 2;
+  return Util.filterRelevantLines(
+    details.lines,
+    details.lineMessages,
+    SURROUNDING_LINES_TO_SHOW_WHEN_COLLAPSED
+  );
+}
+
+/**
+ * Render snippet of text with line numbers and annotations.
+ * By default we only show a few lines around each annotation and the user
+ * can click "Expand snippet" to show more.
+ * Content lines with annotations are highlighted.
+ */
+class SnippetRenderer {
+  /**
+   * @param {DOM} dom
+   * @param {DocumentFragment} tmpl
+   * @param {LH.Audit.Details.SnippetValue} details
+   * @param {DetailsRenderer} detailsRenderer
+   * @param {function} toggleExpandedFn
+   * @return {DocumentFragment}
+   */
+  static renderHeader(dom, tmpl, details, detailsRenderer, toggleExpandedFn) {
+    const linesWhenCollapsed = getLinesWhenCollapsed(details);
+    const canExpand = linesWhenCollapsed.length < details.lines.length;
+
+    const header = dom.cloneTemplate('#tmpl-lh-snippet__header', tmpl);
+    dom.find('.lh-snippet__title', header).textContent = details.title;
+
+    const {
+      snippetCollapseButtonLabel,
+      snippetExpandButtonLabel,
+    } = Util.UIStrings;
+    dom.find(
+      '.lh-snippet__btn-label-collapse',
+      header
+    ).textContent = snippetCollapseButtonLabel;
+    dom.find(
+      '.lh-snippet__btn-label-expand',
+      header
+    ).textContent = snippetExpandButtonLabel;
+
+    const toggleExpandButton = dom.find('.lh-snippet__toggle-expand', header);
+    // If we're already showing all the available lines of the snippet, we don't need an
+    // expand/collapse button and can remove it from the DOM.
+    // If we leave the button in though, wire up the click listener to toggle visibility!
+    if (!canExpand) {
+      toggleExpandButton.remove();
+    } else {
+      toggleExpandButton.addEventListener('click', () => toggleExpandedFn());
+    }
+
+    // We only show the source node of the snippet in DevTools because then the user can
+    // access the full element detail. Just being able to see the outer HTML isn't very useful.
+    if (details.node && dom.isDevTools()) {
+      const nodeContainer = dom.find('.lh-snippet__node', header);
+      nodeContainer.appendChild(detailsRenderer.renderNode(details.node));
+    }
+
+    return header;
+  }
+
+  /**
+   * Renders a line (text content, message, or placeholder) as a DOM element.
+   * @param {DOM} dom
+   * @param {DocumentFragment} tmpl
+   * @param {LineDetails} lineDetails
+   * @return {Element}
+   */
+  static renderSnippetLine(
+      dom,
+      tmpl,
+      {content, lineNumber, truncated, contentType, visibility}
+  ) {
+    const clonedTemplate = dom.cloneTemplate('#tmpl-lh-snippet__line', tmpl);
+    const contentLine = dom.find('.lh-snippet__line', clonedTemplate);
+    const {classList} = contentLine;
+
+    classNamesByContentType[contentType].forEach(typeClass =>
+      classList.add(typeClass)
+    );
+
+    if (visibility === LineVisibility.WHEN_COLLAPSED) {
+      classList.add('lh-snippet__show-if-collapsed');
+    } else if (visibility === LineVisibility.WHEN_EXPANDED) {
+      classList.add('lh-snippet__show-if-expanded');
+    }
+
+    const lineContent = content + (truncated ? '…' : '');
+    const lineContentEl = dom.find('.lh-snippet__line code', contentLine);
+    if (contentType === LineContentType.MESSAGE) {
+      lineContentEl.appendChild(dom.convertMarkdownLinkSnippets(lineContent));
+    } else {
+      lineContentEl.textContent = lineContent;
+    }
+
+    dom.find(
+      '.lh-snippet__line-number',
+      contentLine
+    ).textContent = lineNumber.toString();
+
+    return contentLine;
+  }
+
+  /**
+   * @param {DOM} dom
+   * @param {DocumentFragment} tmpl
+   * @param {{message: string}} message
+   * @return {Element}
+   */
+  static renderMessage(dom, tmpl, message) {
+    return SnippetRenderer.renderSnippetLine(dom, tmpl, {
+      lineNumber: ' ',
+      content: message.message,
+      contentType: LineContentType.MESSAGE,
+    });
+  }
+
+  /**
+   * @param {DOM} dom
+   * @param {DocumentFragment} tmpl
+   * @param {LineVisibility} visibility
+   * @return {Element}
+   */
+  static renderOmittedLinesPlaceholder(dom, tmpl, visibility) {
+    return SnippetRenderer.renderSnippetLine(dom, tmpl, {
+      lineNumber: '…',
+      content: '',
+      visibility,
+      contentType: LineContentType.PLACEHOLDER,
+    });
+  }
+
+  /**
+   * @param {DOM} dom
+   * @param {DocumentFragment} tmpl
+   * @param {LH.Audit.Details.SnippetValue} details
+   * @return {DocumentFragment}
+   */
+  static renderSnippetContent(dom, tmpl, details) {
+    const template = dom.cloneTemplate('#tmpl-lh-snippet__content', tmpl);
+    const snippetEl = dom.find('.lh-snippet__snippet-inner', template);
+
+    // First render messages that don't belong to specific lines
+    details.generalMessages.forEach(m =>
+      snippetEl.append(SnippetRenderer.renderMessage(dom, tmpl, m))
+    );
+    // Then render the lines and their messages, as well as placeholders where lines are omitted
+    snippetEl.append(SnippetRenderer.renderSnippetLines(dom, tmpl, details));
+
+    return template;
+  }
+
+  /**
+   * @param {DOM} dom
+   * @param {DocumentFragment} tmpl
+   * @param {LH.Audit.Details.SnippetValue} details
+   * @return {DocumentFragment}
+   */
+  static renderSnippetLines(dom, tmpl, details) {
+    const {lineMessages, generalMessages, lineCount, lines} = details;
+    const linesWhenCollapsed = getLinesWhenCollapsed(details);
+    const hasOnlyGeneralMessages =
+      generalMessages.length > 0 && lineMessages.length === 0;
+
+    const lineContainer = dom.createFragment();
+
+    // When a line is not shown in the collapsed state we try to see if we also need an
+    // omitted lines placeholder for the expanded state, rather than rendering two separate
+    // placeholders.
+    let hasPendingOmittedLinesPlaceholderForCollapsedState = false;
+
+    for (let lineNumber = 1; lineNumber <= lineCount; lineNumber++) {
+      const {line, previousLine} = getLineAndPreviousLine(lines, lineNumber);
+      const {
+        line: lineWhenCollapsed,
+        previousLine: previousLineWhenCollapsed,
+      } = getLineAndPreviousLine(linesWhenCollapsed, lineNumber);
+
+      const showLineWhenCollapsed = !!lineWhenCollapsed;
+      const showPreviousLineWhenCollapsed = !!previousLineWhenCollapsed;
+
+      // If we went from showing lines in the collapsed state to not showing them
+      // we need to render a placeholder
+      if (showPreviousLineWhenCollapsed && !showLineWhenCollapsed) {
+        hasPendingOmittedLinesPlaceholderForCollapsedState = true;
+      }
+      // If we are back to lines being visible in the collapsed and the placeholder
+      // hasn't been rendered yet then render it now
+      if (
+        showLineWhenCollapsed &&
+        hasPendingOmittedLinesPlaceholderForCollapsedState
+      ) {
+        lineContainer.append(
+          SnippetRenderer.renderOmittedLinesPlaceholder(
+            dom,
+            tmpl,
+            LineVisibility.WHEN_COLLAPSED
+          )
+        );
+        hasPendingOmittedLinesPlaceholderForCollapsedState = false;
+      }
+
+      // Render omitted lines placeholder if we have not already rendered one for this gap
+      const isFirstOmittedLineWhenExpanded = !line && !!previousLine;
+      const isFirstLineOverallAndIsOmittedWhenExpanded =
+        !line && lineNumber === 1;
+      if (
+        isFirstOmittedLineWhenExpanded ||
+        isFirstLineOverallAndIsOmittedWhenExpanded
+      ) {
+        // In the collapsed state we don't show omitted lines placeholders around
+        // the edges of the snippet
+        const hasRenderedAllLinesVisibleWhenCollapsed = !linesWhenCollapsed.some(
+          l => l.lineNumber > lineNumber
+        );
+        const onlyShowWhenExpanded =
+          hasRenderedAllLinesVisibleWhenCollapsed || lineNumber === 1;
+        lineContainer.append(
+          SnippetRenderer.renderOmittedLinesPlaceholder(
+            dom,
+            tmpl,
+            onlyShowWhenExpanded
+              ? LineVisibility.WHEN_EXPANDED
+              : LineVisibility.ALWAYS
+          )
+        );
+        hasPendingOmittedLinesPlaceholderForCollapsedState = false;
+      }
+
+      if (!line) {
+        // Can't render the line if we don't know its content (instead we've rendered a placeholder)
+        continue;
+      }
+
+      // Now render the line and any messages
+      const messages = getMessagesForLineNumber(lineMessages, lineNumber);
+      const highlightLine = messages.length > 0 || hasOnlyGeneralMessages;
+      const contentLineDetails = Object.assign({}, line, {
+        contentType: highlightLine
+          ? LineContentType.CONTENT_HIGHLIGHTED
+          : LineContentType.CONTENT_NORMAL,
+        visibility: lineWhenCollapsed
+          ? LineVisibility.ALWAYS
+          : LineVisibility.WHEN_EXPANDED,
+      });
+      lineContainer.append(
+        SnippetRenderer.renderSnippetLine(dom, tmpl, contentLineDetails)
+      );
+
+      messages.forEach(message => {
+        lineContainer.append(SnippetRenderer.renderMessage(dom, tmpl, message));
+      });
+    }
+
+    return lineContainer;
+  }
+
+  /**
+   * @param {DOM} dom
+   * @param {ParentNode} templateContext
+   * @param {LH.Audit.Details.SnippetValue} details
+   * @param {DetailsRenderer} detailsRenderer
+   * @return {Element}
+   */
+  static render(dom, templateContext, details, detailsRenderer) {
+    const tmpl = dom.cloneTemplate('#tmpl-lh-snippet', templateContext);
+    const snippetEl = dom.find('.lh-snippet', tmpl);
+
+    const header = SnippetRenderer.renderHeader(
+      dom,
+      tmpl,
+      details,
+      detailsRenderer,
+      () => snippetEl.classList.toggle('lh-snippet--expanded')
+    );
+    const content = SnippetRenderer.renderSnippetContent(dom, tmpl, details);
+    snippetEl.append(header, content);
+
+    return snippetEl;
+  }
+}
+
+// Allow Node require()'ing.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = SnippetRenderer;
+} else {
+  self.SnippetRenderer = SnippetRenderer;
+}
+;
+/**
+ * @license Copyright 2017 Google Inc. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+ */
+'use strict';
+
+/* global URL */
+
+/**
+ * @fileoverview
+ * @suppress {reportUnknownTypes}
+ */
+
+/**
+ * Generate a filenamePrefix of hostname_YYYY-MM-DD_HH-MM-SS
+ * Date/time uses the local timezone, however Node has unreliable ICU
+ * support, so we must construct a YYYY-MM-DD date format manually. :/
+ * @param {{finalUrl: string, fetchTime: string}} lhr
+ * @return {string}
+ */
+function getFilenamePrefix(lhr) {
+  const hostname = new URL(lhr.finalUrl).hostname;
+  const date = (lhr.fetchTime && new Date(lhr.fetchTime)) || new Date();
+
+  const timeStr = date.toLocaleTimeString('en-US', {hour12: false});
+  const dateParts = date.toLocaleDateString('en-US', {
+    year: 'numeric', month: '2-digit', day: '2-digit',
+  }).split('/');
+  // @ts-ignore - parts exists
+  dateParts.unshift(dateParts.pop());
+  const dateStr = dateParts.join('-');
+
+  const filenamePrefix = `${hostname}_${dateStr}_${timeStr}`;
+  // replace characters that are unfriendly to filenames
+  return filenamePrefix.replace(/[/?<>\\:*|"]/g, '-');
+}
+
+// don't attempt to export in the browser.
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {getFilenamePrefix};
+}
+;
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * Logs messages via a UI butter.
+ */
+class Logger {
+  /**
+   * @param {Element} element
+   */
+  constructor(element) {
+    /** @type {Element} */
+    this.el = element;
+    this._id = undefined;
+  }
+
+  /**
+   * Shows a butter bar.
+   * @param {string} msg The message to show.
+   * @param {boolean=} autoHide True to hide the message after a duration.
+   *     Default is true.
+   */
+  log(msg, autoHide = true) {
+    this._id && clearTimeout(this._id);
+
+    this.el.textContent = msg;
+    this.el.classList.add('show');
+    if (autoHide) {
+      this._id = setTimeout(_ => {
+        this.el.classList.remove('show');
+      }, 7000);
+    }
+  }
+
+  /**
+   * @param {string} msg
+   */
+  warn(msg) {
+    this.log('Warning: ' + msg);
+  }
+
+  /**
+   * @param {string} msg
+   */
+  error(msg) {
+    this.log(msg);
+
+    // Rethrow to make sure it's auditable as an error, but in a setTimeout so page
+    // recovers gracefully and user can try loading a report again.
+    setTimeout(_ => {
+      throw new Error(msg);
+    }, 0);
+  }
+
+  /**
+   * Explicitly hides the butter bar.
+   */
+  hide() {
+    this._id && clearTimeout(this._id);
+    this.el.classList.remove('show');
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = Logger;
+}
+;
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* eslint-env browser */
+
+/**
+ * @fileoverview Adds tools button, print, and other dynamic functionality to
+ * the report.
+ */
+
+/* globals getFilenamePrefix Util */
+
+/**
+ * @param {HTMLTableElement} tableEl
+ * @return {Array<HTMLTableRowElement>}
+ */
+function getTableRows(tableEl) {
+  return Array.from(tableEl.tBodies[0].rows);
+}
+
+class ReportUIFeatures {
+  /**
+   * @param {DOM} dom
+   */
+  constructor(dom) {
+    /** @type {LH.Result} */
+    this.json; // eslint-disable-line no-unused-expressions
+    /** @type {DOM} */
+    this._dom = dom;
+    /** @type {Document} */
+    this._document = this._dom.document();
+    /** @type {ParentNode} */
+    this._templateContext = this._dom.document();
+    /** @type {DropDown} */
+    this._dropDown = new DropDown(this._dom);
+    /** @type {boolean} */
+    this._copyAttempt = false;
+    /** @type {HTMLElement} */
+    this.topbarEl; // eslint-disable-line no-unused-expressions
+    /** @type {HTMLElement} */
+    this.scoreScaleEl; // eslint-disable-line no-unused-expressions
+    /** @type {HTMLElement} */
+    this.stickyHeaderEl; // eslint-disable-line no-unused-expressions
+    /** @type {HTMLElement} */
+    this.highlightEl; // eslint-disable-line no-unused-expressions
+
+    this.onMediaQueryChange = this.onMediaQueryChange.bind(this);
+    this.onCopy = this.onCopy.bind(this);
+    this.onDropDownMenuClick = this.onDropDownMenuClick.bind(this);
+    this.onKeyUp = this.onKeyUp.bind(this);
+    this.collapseAllDetails = this.collapseAllDetails.bind(this);
+    this.expandAllDetails = this.expandAllDetails.bind(this);
+    this._toggleDarkTheme = this._toggleDarkTheme.bind(this);
+    this._updateStickyHeaderOnScroll = this._updateStickyHeaderOnScroll.bind(this);
+  }
+
+  /**
+   * Adds tools button, print, and other functionality to the report. The method
+   * should be called whenever the report needs to be re-rendered.
+   * @param {LH.Result} report
+   */
+  initFeatures(report) {
+    this.json = report;
+
+    this._setupMediaQueryListeners();
+    this._dropDown.setup(this.onDropDownMenuClick);
+    this._setupThirdPartyFilter();
+    this._setUpCollapseDetailsAfterPrinting();
+    this._resetUIState();
+    this._document.addEventListener('keyup', this.onKeyUp);
+    this._document.addEventListener('copy', this.onCopy);
+
+    const topbarLogo = this._dom.find('.lh-topbar__logo', this._document);
+    topbarLogo.addEventListener('click', () => this._toggleDarkTheme());
+
+    let turnOffTheLights = false;
+    // Do not query the system preferences for DevTools - DevTools should only apply dark theme
+    // if dark is selected in the settings panel.
+    if (!this._dom.isDevTools() && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      turnOffTheLights = true;
+    }
+
+    // Fireworks.
+    const scoresAll100 = Object.values(report.categories).every(cat => cat.score === 1);
+    const hasAllCoreCategories =
+      Object.keys(report.categories).filter(id => !Util.isPluginCategory(id)).length >= 5;
+    if (scoresAll100 && hasAllCoreCategories) {
+      turnOffTheLights = true;
+      this._enableFireworks();
+    }
+
+    if (turnOffTheLights) {
+      this._toggleDarkTheme(true);
+    }
+
+    // There is only a sticky header when at least 2 categories are present.
+    if (Object.keys(this.json.categories).length >= 2) {
+      this._setupStickyHeaderElements();
+      const containerEl = this._dom.find('.lh-container', this._document);
+      const elToAddScrollListener = this._getScrollParent(containerEl);
+      elToAddScrollListener.addEventListener('scroll', this._updateStickyHeaderOnScroll);
+
+      // Use ResizeObserver where available.
+      // TODO: there is an issue with incorrect position numbers and, as a result, performance
+      // issues due to layout thrashing.
+      // See https://github.com/GoogleChrome/lighthouse/pull/9023/files#r288822287 for details.
+      // For now, limit to DevTools.
+      if (this._dom.isDevTools()) {
+        const resizeObserver = new window.ResizeObserver(this._updateStickyHeaderOnScroll);
+        resizeObserver.observe(containerEl);
+      } else {
+        window.addEventListener('resize', this._updateStickyHeaderOnScroll);
+      }
+    }
+
+    // Show the metric descriptions by default when there is an error.
+    const hasMetricError = report.categories.performance && report.categories.performance.auditRefs
+      .some(audit => Boolean(audit.group === 'metrics' && report.audits[audit.id].errorMessage));
+    if (hasMetricError) {
+      const toggleInputEl = /** @type {HTMLInputElement} */ (
+        this._dom.find('.lh-metrics-toggle__input', this._document));
+      toggleInputEl.checked = true;
+    }
+  }
+
+  /**
+   * Define a custom element for <templates> to be extracted from. For example:
+   *     this.setTemplateContext(new DOMParser().parseFromString(htmlStr, 'text/html'))
+   * @param {ParentNode} context
+   */
+  setTemplateContext(context) {
+    this._templateContext = context;
+  }
+
+  /**
+   * Finds the first scrollable ancestor of `element`. Falls back to the document.
+   * @param {HTMLElement} element
+   * @return {Node}
+   */
+  _getScrollParent(element) {
+    const {overflowY} = window.getComputedStyle(element);
+    const isScrollable = overflowY !== 'visible' && overflowY !== 'hidden';
+
+    if (isScrollable) {
+      return element;
+    }
+
+    if (element.parentElement) {
+      return this._getScrollParent(element.parentElement);
+    }
+
+    return document;
+  }
+
+  _enableFireworks() {
+    const scoresContainer = this._dom.find('.lh-scores-container', this._document);
+    scoresContainer.classList.add('score100');
+    scoresContainer.addEventListener('click', _ => {
+      scoresContainer.classList.toggle('fireworks-paused');
+    });
+  }
+
+  /**
+   * Fires a custom DOM event on target.
+   * @param {string} name Name of the event.
+   * @param {Node=} target DOM node to fire the event on.
+   * @param {*=} detail Custom data to include.
+   */
+  _fireEventOn(name, target = this._document, detail) {
+    const event = new CustomEvent(name, detail ? {detail} : undefined);
+    target.dispatchEvent(event);
+  }
+
+  _setupMediaQueryListeners() {
+    const mediaQuery = self.matchMedia('(max-width: 500px)');
+    mediaQuery.addListener(this.onMediaQueryChange);
+    // Ensure the handler is called on init
+    this.onMediaQueryChange(mediaQuery);
+  }
+
+  /**
+   * Handle media query change events.
+   * @param {MediaQueryList|MediaQueryListEvent} mql
+   */
+  onMediaQueryChange(mql) {
+    const root = this._dom.find('.lh-root', this._document);
+    root.classList.toggle('lh-narrow', mql.matches);
+  }
+
+  _setupThirdPartyFilter() {
+    // Some audits should not display the third party filter option.
+    const thirdPartyFilterAuditExclusions = [
+      // This audit deals explicitly with third party resources.
+      'uses-rel-preconnect',
+    ];
+
+    // Get all tables with a text url column.
+    /** @type {Array<HTMLTableElement>} */
+    const tables = Array.from(this._document.querySelectorAll('.lh-table'));
+    const tablesWithUrls = tables
+      .filter(el => el.querySelector('td.lh-table-column--url'))
+      .filter(el => {
+        const containingAudit = el.closest('.lh-audit');
+        if (!containingAudit) throw new Error('.lh-table not within audit');
+        return !thirdPartyFilterAuditExclusions.includes(containingAudit.id);
+      });
+
+    tablesWithUrls.forEach((tableEl, index) => {
+      const urlItems = this._getUrlItems(tableEl);
+      const thirdPartyRows = this._getThirdPartyRows(tableEl, urlItems, this.json.finalUrl);
+
+      // create input box
+      const filterTemplate = this._dom.cloneTemplate('#tmpl-lh-3p-filter', this._templateContext);
+      const filterInput =
+        /** @type {HTMLInputElement} */ (this._dom.find('input', filterTemplate));
+      const id = `lh-3p-filter-label--${index}`;
+
+      filterInput.id = id;
+      filterInput.addEventListener('change', e => {
+        // Remove rows from the dom and keep track of them to re-add on uncheck.
+        // Why removing instead of hiding? To keep nth-child(even) background-colors working.
+        if (e.target instanceof HTMLInputElement && !e.target.checked) {
+          for (const row of thirdPartyRows.values()) {
+            row.remove();
+          }
+        } else {
+          // Add row elements back to original positions.
+          for (const [position, row] of thirdPartyRows.entries()) {
+            const childrenArr = getTableRows(tableEl);
+            tableEl.tBodies[0].insertBefore(row, childrenArr[position]);
+          }
+        }
+      });
+
+      this._dom.find('label', filterTemplate).setAttribute('for', id);
+      this._dom.find('.lh-3p-filter-count', filterTemplate).textContent =
+          `${thirdPartyRows.size}`;
+      this._dom.find('.lh-3p-ui-string', filterTemplate).textContent =
+          Util.UIStrings.thirdPartyResourcesLabel;
+
+      // If all or none of the rows are 3rd party, disable the checkbox.
+      if (thirdPartyRows.size === urlItems.length || !thirdPartyRows.size) {
+        filterInput.disabled = true;
+        filterInput.checked = thirdPartyRows.size === urlItems.length;
+      }
+
+      // Finally, add checkbox to the DOM.
+      if (!tableEl.parentNode) return; // Keep tsc happy.
+      tableEl.parentNode.insertBefore(filterTemplate, tableEl);
+    });
+  }
+
+  /**
+   * From a table with URL entries, finds the rows containing third-party URLs
+   * and returns a Map of those rows, mapping from row index to row Element.
+   * @param {HTMLTableElement} el
+   * @param {string} finalUrl
+   * @param {Array<HTMLElement>} urlItems
+   * @return {Map<number, HTMLTableRowElement>}
+   */
+  _getThirdPartyRows(el, urlItems, finalUrl) {
+    const finalUrlRootDomain = Util.getRootDomain(finalUrl);
+
+    /** @type {Map<number, HTMLTableRowElement>} */
+    const thirdPartyRows = new Map();
+    for (const urlItem of urlItems) {
+      const datasetUrl = urlItem.dataset.url;
+      if (!datasetUrl) continue;
+      const isThirdParty = Util.getRootDomain(datasetUrl) !== finalUrlRootDomain;
+      if (!isThirdParty) continue;
+
+      const urlRowEl = urlItem.closest('tr');
+      if (urlRowEl) {
+        const rowPosition = getTableRows(el).indexOf(urlRowEl);
+        thirdPartyRows.set(rowPosition, urlRowEl);
+      }
+    }
+
+    return thirdPartyRows;
+  }
+
+  /**
+   * From a table, finds and returns URL items.
+   * @param {HTMLTableElement} tableEl
+   * @return {Array<HTMLElement>}
+   */
+  _getUrlItems(tableEl) {
+    return this._dom.findAll('.lh-text__url', tableEl);
+  }
+
+  _setupStickyHeaderElements() {
+    this.topbarEl = this._dom.find('.lh-topbar', this._document);
+    this.scoreScaleEl = this._dom.find('.lh-scorescale', this._document);
+    this.stickyHeaderEl = this._dom.find('.lh-sticky-header', this._document);
+
+    // Highlighter will be absolutely positioned at first gauge, then transformed on scroll.
+    this.highlightEl = this._dom.createChildOf(this.stickyHeaderEl, 'div', 'lh-highlighter');
+  }
+
+  /**
+   * Handle copy events.
+   * @param {ClipboardEvent} e
+   */
+  onCopy(e) {
+    // Only handle copy button presses (e.g. ignore the user copying page text).
+    if (this._copyAttempt && e.clipboardData) {
+      // We want to write our own data to the clipboard, not the user's text selection.
+      e.preventDefault();
+      e.clipboardData.setData('text/plain', JSON.stringify(this.json, null, 2));
+
+      this._fireEventOn('lh-log', this._document, {
+        cmd: 'log', msg: 'Report JSON copied to clipboard',
+      });
+    }
+
+    this._copyAttempt = false;
+  }
+
+  /**
+   * Copies the report JSON to the clipboard (if supported by the browser).
+   */
+  onCopyButtonClick() {
+    this._fireEventOn('lh-analytics', this._document, {
+      cmd: 'send',
+      fields: {hitType: 'event', eventCategory: 'report', eventAction: 'copy'},
+    });
+
+    try {
+      if (this._document.queryCommandSupported('copy')) {
+        this._copyAttempt = true;
+
+        // Note: In Safari 10.0.1, execCommand('copy') returns true if there's
+        // a valid text selection on the page. See http://caniuse.com/#feat=clipboard.
+        if (!this._document.execCommand('copy')) {
+          this._copyAttempt = false; // Prevent event handler from seeing this as a copy attempt.
+
+          this._fireEventOn('lh-log', this._document, {
+            cmd: 'warn', msg: 'Your browser does not support copy to clipboard.',
+          });
+        }
+      }
+    } catch (/** @type {Error} */ e) {
+      this._copyAttempt = false;
+      this._fireEventOn('lh-log', this._document, {cmd: 'log', msg: e.message});
+    }
+  }
+
+  /**
+   * Resets the state of page before capturing the page for export.
+   * When the user opens the exported HTML page, certain UI elements should
+   * be in their closed state (not opened) and the templates should be unstamped.
+   */
+  _resetUIState() {
+    this._dropDown.close();
+    this._dom.resetTemplates();
+  }
+
+  /**
+   * Handler for tool button.
+   * @param {Event} e
+   */
+  onDropDownMenuClick(e) {
+    e.preventDefault();
+
+    const el = /** @type {?Element} */ (e.target);
+
+    if (!el || !el.hasAttribute('data-action')) {
+      return;
+    }
+
+    switch (el.getAttribute('data-action')) {
+      case 'copy':
+        this.onCopyButtonClick();
+        break;
+      case 'print-summary':
+        this.collapseAllDetails();
+        this._print();
+        break;
+      case 'print-expanded':
+        this.expandAllDetails();
+        this._print();
+        break;
+      case 'save-json': {
+        const jsonStr = JSON.stringify(this.json, null, 2);
+        this._saveFile(new Blob([jsonStr], {type: 'application/json'}));
+        break;
+      }
+      case 'save-html': {
+        const htmlStr = this.getReportHtml();
+        try {
+          this._saveFile(new Blob([htmlStr], {type: 'text/html'}));
+        } catch (/** @type {Error} */ e) {
+          this._fireEventOn('lh-log', this._document, {
+            cmd: 'error', msg: 'Could not export as HTML. ' + e.message,
+          });
+        }
+        break;
+      }
+      case 'open-viewer': {
+        const viewerPath = '/lighthouse/viewer/';
+        ReportUIFeatures.openTabAndSendJsonReport(this.json, viewerPath);
+        break;
+      }
+      case 'save-gist': {
+        this.saveAsGist();
+        break;
+      }
+      case 'toggle-dark': {
+        this._toggleDarkTheme();
+        break;
+      }
+    }
+
+    this._dropDown.close();
+  }
+
+  _print() {
+    self.print();
+  }
+
+  /**
+   * Keyup handler for the document.
+   * @param {KeyboardEvent} e
+   */
+  onKeyUp(e) {
+    // Ctrl+P - Expands audit details when user prints via keyboard shortcut.
+    if ((e.ctrlKey || e.metaKey) && e.keyCode === 80) {
+      this._dropDown.close();
+    }
+  }
+
+  /**
+   * Opens a new tab to the online viewer and sends the local page's JSON results
+   * to the online viewer using postMessage.
+   * @param {LH.Result} reportJson
+   * @param {string} viewerPath
+   * @protected
+   */
+  static openTabAndSendJsonReport(reportJson, viewerPath) {
+    const VIEWER_ORIGIN = 'https://googlechrome.github.io';
+    // Chrome doesn't allow us to immediately postMessage to a popup right
+    // after it's created. Normally, we could also listen for the popup window's
+    // load event, however it is cross-domain and won't fire. Instead, listen
+    // for a message from the target app saying "I'm open".
+    const json = reportJson;
+    window.addEventListener('message', function msgHandler(messageEvent) {
+      if (messageEvent.origin !== VIEWER_ORIGIN) {
+        return;
+      }
+      if (popup && messageEvent.data.opened) {
+        popup.postMessage({lhresults: json}, VIEWER_ORIGIN);
+        window.removeEventListener('message', msgHandler);
+      }
+    });
+
+    // The popup's window.name is keyed by version+url+fetchTime, so we reuse/select tabs correctly
+    // @ts-ignore - If this is a v2 LHR, use old `generatedTime`.
+    const fallbackFetchTime = /** @type {string} */ (json.generatedTime);
+    const fetchTime = json.fetchTime || fallbackFetchTime;
+    const windowName = `${json.lighthouseVersion}-${json.requestedUrl}-${fetchTime}`;
+    const popup = window.open(`${VIEWER_ORIGIN}${viewerPath}`, windowName);
+  }
+
+  /**
+   * Expands all audit `<details>`.
+   * Ideally, a print stylesheet could take care of this, but CSS has no way to
+   * open a `<details>` element.
+   */
+  expandAllDetails() {
+    const details = /** @type {Array<HTMLDetailsElement>} */ (this._dom.findAll(
+        '.lh-categories details', this._document));
+    details.map(detail => detail.open = true);
+  }
+
+  /**
+   * Collapses all audit `<details>`.
+   * open a `<details>` element.
+   */
+  collapseAllDetails() {
+    const details = /** @type {Array<HTMLDetailsElement>} */ (this._dom.findAll(
+        '.lh-categories details', this._document));
+    details.map(detail => detail.open = false);
+  }
+
+  /**
+   * Sets up listeners to collapse audit `<details>` when the user closes the
+   * print dialog, all `<details>` are collapsed.
+   */
+  _setUpCollapseDetailsAfterPrinting() {
+    // FF and IE implement these old events.
+    if ('onbeforeprint' in self) {
+      self.addEventListener('afterprint', this.collapseAllDetails);
+    } else {
+      const win = /** @type {Window} */ (self);
+      // Note: FF implements both window.onbeforeprint and media listeners. However,
+      // it doesn't matchMedia doesn't fire when matching 'print'.
+      win.matchMedia('print').addListener(mql => {
+        if (mql.matches) {
+          this.expandAllDetails();
+        } else {
+          this.collapseAllDetails();
+        }
+      });
+    }
+  }
+
+  /**
+   * Returns the html that recreates this report.
+   * @return {string}
+   * @protected
+   */
+  getReportHtml() {
+    this._resetUIState();
+    return this._document.documentElement.outerHTML;
+  }
+
+  /**
+   * Save json as a gist. Unimplemented in base UI features.
+   * @protected
+   */
+  saveAsGist() {
+    throw new Error('Cannot save as gist from base report');
+  }
+
+  /**
+   * Downloads a file (blob) using a[download].
+   * @param {Blob|File} blob The file to save.
+   * @private
+   */
+  _saveFile(blob) {
+    const filename = getFilenamePrefix({
+      finalUrl: this.json.finalUrl,
+      fetchTime: this.json.fetchTime,
+    });
+
+    const ext = blob.type.match('json') ? '.json' : '.html';
+    const href = URL.createObjectURL(blob);
+
+    const a = this._dom.createElement('a');
+    a.download = `${filename}${ext}`;
+    a.href = href;
+    this._document.body.appendChild(a); // Firefox requires anchor to be in the DOM.
+    a.click();
+
+    // cleanup.
+    this._document.body.removeChild(a);
+    setTimeout(_ => URL.revokeObjectURL(href), 500);
+  }
+
+  /**
+   * @private
+   * @param {boolean} [force]
+   */
+  _toggleDarkTheme(force) {
+    const el = this._dom.find('.lh-vars', this._document);
+    // This seems unnecessary, but in DevTools, passing "undefined" as the second
+    // parameter acts like passing "false".
+    // https://github.com/ChromeDevTools/devtools-frontend/blob/dd6a6d4153647c2a4203c327c595692c5e0a4256/front_end/dom_extension/DOMExtension.js#L809-L819
+    if (typeof force === 'undefined') {
+      el.classList.toggle('dark');
+    } else {
+      el.classList.toggle('dark', force);
+    }
+  }
+
+  _updateStickyHeaderOnScroll() {
+    // Show sticky header when the score scale begins to go underneath the topbar.
+    const topbarBottom = this.topbarEl.getBoundingClientRect().bottom;
+    const scoreScaleTop = this.scoreScaleEl.getBoundingClientRect().top;
+    const showStickyHeader = topbarBottom >= scoreScaleTop;
+
+    // Highlight mini gauge when section is in view.
+    // In view = the last category that starts above the middle of the window.
+    const categoryEls = Array.from(this._document.querySelectorAll('.lh-category'));
+    const categoriesAboveTheMiddle =
+      categoryEls.filter(el => el.getBoundingClientRect().top - window.innerHeight / 2 < 0);
+    const highlightIndex =
+      categoriesAboveTheMiddle.length > 0 ? categoriesAboveTheMiddle.length - 1 : 0;
+
+    // Category order matches gauge order in sticky header.
+    const gaugeWrapperEls = this.stickyHeaderEl.querySelectorAll('.lh-gauge__wrapper');
+    const gaugeToHighlight = gaugeWrapperEls[highlightIndex];
+    const origin = gaugeWrapperEls[0].getBoundingClientRect().left;
+    const offset = gaugeToHighlight.getBoundingClientRect().left - origin;
+
+    // Mutate at end to avoid layout thrashing.
+    this.highlightEl.style.transform = `translate(${offset}px)`;
+    this.stickyHeaderEl.classList.toggle('lh-sticky-header--visible', showStickyHeader);
+  }
+}
+
+class DropDown {
+  /**
+   * @param {DOM} dom
+   */
+  constructor(dom) {
+    /** @type {DOM} */
+    this._dom = dom;
+    /** @type {HTMLElement} */
+    this._toggleEl; // eslint-disable-line no-unused-expressions
+    /** @type {HTMLElement} */
+    this._menuEl; // eslint-disable-line no-unused-expressions
+
+    this.onDocumentKeyDown = this.onDocumentKeyDown.bind(this);
+    this.onToggleClick = this.onToggleClick.bind(this);
+    this.onToggleKeydown = this.onToggleKeydown.bind(this);
+    this.onMenuKeydown = this.onMenuKeydown.bind(this);
+
+    this._getNextMenuItem = this._getNextMenuItem.bind(this);
+    this._getNextSelectableNode = this._getNextSelectableNode.bind(this);
+    this._getPreviousMenuItem = this._getPreviousMenuItem.bind(this);
+  }
+
+  /**
+   * @param {function(MouseEvent): any} menuClickHandler
+   */
+  setup(menuClickHandler) {
+    this._toggleEl = this._dom.find('.lh-tools__button', this._dom.document());
+    this._toggleEl.addEventListener('click', this.onToggleClick);
+    this._toggleEl.addEventListener('keydown', this.onToggleKeydown);
+
+    this._menuEl = this._dom.find('.lh-tools__dropdown', this._dom.document());
+    this._menuEl.addEventListener('keydown', this.onMenuKeydown);
+    this._menuEl.addEventListener('click', menuClickHandler);
+  }
+
+  close() {
+    this._toggleEl.classList.remove('active');
+    this._toggleEl.setAttribute('aria-expanded', 'false');
+    if (this._menuEl.contains(this._dom.document().activeElement)) {
+      // Refocus on the tools button if the drop down last had focus
+      this._toggleEl.focus();
+    }
+    this._dom.document().removeEventListener('keydown', this.onDocumentKeyDown);
+  }
+
+  /**
+   * @param {HTMLElement} firstFocusElement
+   */
+  open(firstFocusElement) {
+    if (this._toggleEl.classList.contains('active')) {
+      // If the drop down is already open focus on the element
+      firstFocusElement.focus();
+    } else {
+      // Wait for drop down transition to complete so options are focusable.
+      this._menuEl.addEventListener('transitionend', () => {
+        firstFocusElement.focus();
+      }, {once: true});
+    }
+
+    this._toggleEl.classList.add('active');
+    this._toggleEl.setAttribute('aria-expanded', 'true');
+    this._dom.document().addEventListener('keydown', this.onDocumentKeyDown);
+  }
+
+  /**
+   * Click handler for tools button.
+   * @param {Event} e
+   */
+  onToggleClick(e) {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+
+    if (this._toggleEl.classList.contains('active')) {
+      this.close();
+    } else {
+      this.open(this._getNextMenuItem());
+    }
+  }
+
+  /**
+   * Handler for tool button.
+   * @param {KeyboardEvent} e
+   */
+  onToggleKeydown(e) {
+    switch (e.code) {
+      case 'ArrowUp':
+        e.preventDefault();
+        this.open(this._getPreviousMenuItem());
+        break;
+      case 'ArrowDown':
+      case 'Enter':
+      case ' ':
+        e.preventDefault();
+        this.open(this._getNextMenuItem());
+        break;
+      default:
+       // no op
+    }
+  }
+
+  /**
+   * Handler for tool DropDown.
+   * @param {KeyboardEvent} e
+   */
+  onMenuKeydown(e) {
+    const el = /** @type {?HTMLElement} */ (e.target);
+
+    switch (e.code) {
+      case 'ArrowUp':
+        e.preventDefault();
+        this._getPreviousMenuItem(el).focus();
+        break;
+      case 'ArrowDown':
+        e.preventDefault();
+        this._getNextMenuItem(el).focus();
+        break;
+      case 'Home':
+        e.preventDefault();
+        this._getNextMenuItem().focus();
+        break;
+      case 'End':
+        e.preventDefault();
+        this._getPreviousMenuItem().focus();
+        break;
+      default:
+       // no op
+    }
+  }
+
+  /**
+   * Keydown handler for the document.
+   * @param {KeyboardEvent} e
+   */
+  onDocumentKeyDown(e) {
+    if (e.keyCode === 27) { // ESC
+      this.close();
+    }
+  }
+
+  /**
+   * @param {Array<Node>} allNodes
+   * @param {?Node=} startNode
+   * @returns {Node}
+   */
+  _getNextSelectableNode(allNodes, startNode) {
+    const nodes = allNodes.filter((node) => {
+      if (!(node instanceof HTMLElement)) {
+        return false;
+      }
+
+      // 'Save as Gist' option may be disabled.
+      if (node.hasAttribute('disabled')) {
+        return false;
+      }
+
+      // 'Save as Gist' option may have display none.
+      if (window.getComputedStyle(node).display === 'none') {
+        return false;
+      }
+
+      return true;
+    });
+
+    let nextIndex = startNode ? (nodes.indexOf(startNode) + 1) : 0;
+    if (nextIndex >= nodes.length) {
+      nextIndex = 0;
+    }
+
+    return nodes[nextIndex];
+  }
+
+  /**
+   * @param {?Element=} startEl
+   * @returns {HTMLElement}
+   */
+  _getNextMenuItem(startEl) {
+    const nodes = Array.from(this._menuEl.childNodes);
+    return /** @type {HTMLElement} */ (this._getNextSelectableNode(nodes, startEl));
+  }
+
+  /**
+   * @param {?Element=} startEl
+   * @returns {HTMLElement}
+   */
+  _getPreviousMenuItem(startEl) {
+    const nodes = Array.from(this._menuEl.childNodes).reverse();
+    return /** @type {HTMLElement} */ (this._getNextSelectableNode(nodes, startEl));
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = ReportUIFeatures;
+} else {
+  self.ReportUIFeatures = ReportUIFeatures;
+}
+;
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* globals self, Util */
+
+/** @typedef {import('./dom.js')} DOM */
+/** @typedef {import('./report-renderer.js')} ReportRenderer */
+/** @typedef {import('./details-renderer.js')} DetailsRenderer */
+/** @typedef {import('./util.js')} Util */
+/** @typedef {'failed'|'warning'|'manual'|'passed'|'notApplicable'} TopLevelClumpId */
+
+class CategoryRenderer {
+  /**
+   * @param {DOM} dom
+   * @param {DetailsRenderer} detailsRenderer
+   */
+  constructor(dom, detailsRenderer) {
+    /** @type {DOM} */
+    this.dom = dom;
+    /** @type {DetailsRenderer} */
+    this.detailsRenderer = detailsRenderer;
+    /** @type {ParentNode} */
+    this.templateContext = this.dom.document();
+
+    this.detailsRenderer.setTemplateContext(this.templateContext);
+  }
+
+  /**
+   * Display info per top-level clump. Define on class to avoid race with Util init.
+   */
+  get _clumpTitles() {
+    return {
+      warning: Util.UIStrings.warningAuditsGroupTitle,
+      manual: Util.UIStrings.manualAuditsGroupTitle,
+      passed: Util.UIStrings.passedAuditsGroupTitle,
+      notApplicable: Util.UIStrings.notApplicableAuditsGroupTitle,
+    };
+  }
+
+  /**
+   * @param {LH.ReportResult.AuditRef} audit
+   * @return {Element}
+   */
+  renderAudit(audit) {
+    const tmpl = this.dom.cloneTemplate('#tmpl-lh-audit', this.templateContext);
+    return this.populateAuditValues(audit, tmpl);
+  }
+
+  /**
+   * Populate an DOM tree with audit details. Used by renderAudit and renderOpportunity
+   * @param {LH.ReportResult.AuditRef} audit
+   * @param {DocumentFragment} tmpl
+   * @return {Element}
+   */
+  populateAuditValues(audit, tmpl) {
+    const auditEl = this.dom.find('.lh-audit', tmpl);
+    auditEl.id = audit.result.id;
+    const scoreDisplayMode = audit.result.scoreDisplayMode;
+
+    if (audit.result.displayValue) {
+      this.dom.find('.lh-audit__display-text', auditEl).textContent = audit.result.displayValue;
+    }
+
+    const titleEl = this.dom.find('.lh-audit__title', auditEl);
+    titleEl.appendChild(this.dom.convertMarkdownCodeSnippets(audit.result.title));
+    this.dom.find('.lh-audit__description', auditEl)
+        .appendChild(this.dom.convertMarkdownLinkSnippets(audit.result.description));
+
+    if (audit.stackPacks) {
+      audit.stackPacks.forEach(pack => {
+        const packElm = this.dom.createElement('div');
+        packElm.classList.add('lh-audit__stackpack');
+
+        const packElmImg = this.dom.createElement('img');
+        packElmImg.classList.add('lh-audit__stackpack__img');
+        packElmImg.src = pack.iconDataURL;
+        packElmImg.alt = pack.title;
+        packElm.appendChild(packElmImg);
+
+        packElm.appendChild(this.dom.convertMarkdownLinkSnippets(pack.description));
+
+        this.dom.find('.lh-audit__stackpacks', auditEl)
+          .appendChild(packElm);
+      });
+    }
+
+    const header = /** @type {HTMLDetailsElement} */ (this.dom.find('details', auditEl));
+    if (audit.result.details) {
+      const elem = this.detailsRenderer.render(audit.result.details);
+      if (elem) {
+        elem.classList.add('lh-details');
+        header.appendChild(elem);
+      }
+    }
+
+    // Add chevron SVG to the end of the summary
+    this.dom.find('.lh-chevron-container', auditEl).appendChild(this._createChevron());
+    this._setRatingClass(auditEl, audit.result.score, scoreDisplayMode);
+
+    if (audit.result.scoreDisplayMode === 'error') {
+      auditEl.classList.add(`lh-audit--error`);
+      const textEl = this.dom.find('.lh-audit__display-text', auditEl);
+      textEl.textContent = Util.UIStrings.errorLabel;
+      textEl.classList.add('tooltip-boundary');
+      const tooltip = this.dom.createChildOf(textEl, 'div', 'tooltip tooltip--error');
+      tooltip.textContent = audit.result.errorMessage || Util.UIStrings.errorMissingAuditInfo;
+    } else if (audit.result.explanation) {
+      const explEl = this.dom.createChildOf(titleEl, 'div', 'lh-audit-explanation');
+      explEl.textContent = audit.result.explanation;
+    }
+    const warnings = audit.result.warnings;
+    if (!warnings || warnings.length === 0) return auditEl;
+
+    // Add list of warnings or singular warning
+    const warningsEl = this.dom.createChildOf(titleEl, 'div', 'lh-warnings');
+    this.dom.createChildOf(warningsEl, 'span').textContent = Util.UIStrings.warningHeader;
+    if (warnings.length === 1) {
+      warningsEl.appendChild(this.dom.document().createTextNode(warnings.join('')));
+    } else {
+      const warningsUl = this.dom.createChildOf(warningsEl, 'ul');
+      for (const warning of warnings) {
+        const item = this.dom.createChildOf(warningsUl, 'li');
+        item.textContent = warning;
+      }
+    }
+    return auditEl;
+  }
+
+  /**
+   * @return {HTMLElement}
+   */
+  _createChevron() {
+    const chevronTmpl = this.dom.cloneTemplate('#tmpl-lh-chevron', this.templateContext);
+    const chevronEl = this.dom.find('.lh-chevron', chevronTmpl);
+    return chevronEl;
+  }
+
+  /**
+   * @param {Element} element DOM node to populate with values.
+   * @param {number|null} score
+   * @param {string} scoreDisplayMode
+   * @return {Element}
+   */
+  _setRatingClass(element, score, scoreDisplayMode) {
+    const rating = Util.calculateRating(score, scoreDisplayMode);
+    element.classList.add(`lh-audit--${scoreDisplayMode.toLowerCase()}`);
+    if (scoreDisplayMode !== 'informative') {
+      element.classList.add(`lh-audit--${rating}`);
+    }
+    return element;
+  }
+
+  /**
+   * @param {LH.ReportResult.Category} category
+   * @param {Record<string, LH.Result.ReportGroup>} groupDefinitions
+   * @return {Element}
+   */
+  renderCategoryHeader(category, groupDefinitions) {
+    const tmpl = this.dom.cloneTemplate('#tmpl-lh-category-header', this.templateContext);
+
+    const gaugeContainerEl = this.dom.find('.lh-score__gauge', tmpl);
+    const gaugeEl = this.renderScoreGauge(category, groupDefinitions);
+    gaugeContainerEl.appendChild(gaugeEl);
+
+    if (category.description) {
+      const descEl = this.dom.convertMarkdownLinkSnippets(category.description);
+      this.dom.find('.lh-category-header__description', tmpl).appendChild(descEl);
+    }
+
+    return /** @type {Element} */ (tmpl.firstElementChild);
+  }
+
+  /**
+   * Renders the group container for a group of audits. Individual audit elements can be added
+   * directly to the returned element.
+   * @param {LH.Result.ReportGroup} group
+   * @return {Element}
+   */
+  renderAuditGroup(group) {
+    const groupEl = this.dom.createElement('div', 'lh-audit-group');
+
+    const auditGroupHeader = this.dom.createElement('div', 'lh-audit-group__header');
+
+    this.dom.createChildOf(auditGroupHeader, 'span', 'lh-audit-group__title')
+      .textContent = group.title;
+    if (group.description) {
+      const descriptionEl = this.dom.convertMarkdownLinkSnippets(group.description);
+      descriptionEl.classList.add('lh-audit-group__description');
+      auditGroupHeader.appendChild(descriptionEl);
+    }
+    groupEl.appendChild(auditGroupHeader);
+
+    return groupEl;
+  }
+
+  /**
+   * Takes an array of auditRefs, groups them if requested, then returns an
+   * array of audit and audit-group elements.
+   * @param {Array<LH.ReportResult.AuditRef>} auditRefs
+   * @param {Object<string, LH.Result.ReportGroup>} groupDefinitions
+   * @return {Array<Element>}
+   */
+  _renderGroupedAudits(auditRefs, groupDefinitions) {
+    // Audits grouped by their group (or under notAGroup).
+    /** @type {Map<string, Array<LH.ReportResult.AuditRef>>} */
+    const grouped = new Map();
+
+    // Add audits without a group first so they will appear first.
+    const notAGroup = 'NotAGroup';
+    grouped.set(notAGroup, []);
+
+    for (const auditRef of auditRefs) {
+      const groupId = auditRef.group || notAGroup;
+      const groupAuditRefs = grouped.get(groupId) || [];
+      groupAuditRefs.push(auditRef);
+      grouped.set(groupId, groupAuditRefs);
+    }
+
+    /** @type {Array<Element>} */
+    const auditElements = [];
+
+    for (const [groupId, groupAuditRefs] of grouped) {
+      if (groupId === notAGroup) {
+        // Push not-grouped audits individually.
+        for (const auditRef of groupAuditRefs) {
+          auditElements.push(this.renderAudit(auditRef));
+        }
+        continue;
+      }
+
+      // Push grouped audits as a group.
+      const groupDef = groupDefinitions[groupId];
+      const auditGroupElem = this.renderAuditGroup(groupDef);
+      for (const auditRef of groupAuditRefs) {
+        auditGroupElem.appendChild(this.renderAudit(auditRef));
+      }
+      auditGroupElem.classList.add(`lh-audit-group--${groupId}`);
+      auditElements.push(auditGroupElem);
+    }
+
+    return auditElements;
+  }
+
+  /**
+   * Take a set of audits, group them if they have groups, then render in a top-level
+   * clump that can't be expanded/collapsed.
+   * @param {Array<LH.ReportResult.AuditRef>} auditRefs
+   * @param {Object<string, LH.Result.ReportGroup>} groupDefinitions
+   * @return {Element}
+   */
+  renderUnexpandableClump(auditRefs, groupDefinitions) {
+    const clumpElement = this.dom.createElement('div');
+    const elements = this._renderGroupedAudits(auditRefs, groupDefinitions);
+    elements.forEach(elem => clumpElement.appendChild(elem));
+    return clumpElement;
+  }
+
+  /**
+   * Take a set of audits and render in a top-level, expandable clump that starts
+   * in a collapsed state.
+   * @param {Exclude<TopLevelClumpId, 'failed'>} clumpId
+   * @param {{auditRefs: Array<LH.ReportResult.AuditRef>, description?: string}} clumpOpts
+   * @return {Element}
+   */
+  renderClump(clumpId, {auditRefs, description}) {
+    const clumpTmpl = this.dom.cloneTemplate('#tmpl-lh-clump', this.templateContext);
+    const clumpElement = this.dom.find('.lh-clump', clumpTmpl);
+
+    if (clumpId === 'warning') {
+      clumpElement.setAttribute('open', '');
+    }
+
+    const summaryInnerEl = this.dom.find('.lh-audit-group__summary', clumpElement);
+    const chevronEl = summaryInnerEl.appendChild(this._createChevron());
+    chevronEl.title = Util.UIStrings.auditGroupExpandTooltip;
+
+    const headerEl = this.dom.find('.lh-audit-group__header', clumpElement);
+    const title = this._clumpTitles[clumpId];
+    this.dom.find('.lh-audit-group__title', headerEl).textContent = title;
+    if (description) {
+      const descriptionEl = this.dom.convertMarkdownLinkSnippets(description);
+      descriptionEl.classList.add('lh-audit-group__description');
+      headerEl.appendChild(descriptionEl);
+    }
+
+    const itemCountEl = this.dom.find('.lh-audit-group__itemcount', clumpElement);
+    itemCountEl.textContent = `(${auditRefs.length})`;
+
+    // Add all audit results to the clump.
+    const auditElements = auditRefs.map(this.renderAudit.bind(this));
+    clumpElement.append(...auditElements);
+
+    clumpElement.classList.add(`lh-clump--${clumpId.toLowerCase()}`);
+    return clumpElement;
+  }
+
+  /**
+   * @param {ParentNode} context
+   */
+  setTemplateContext(context) {
+    this.templateContext = context;
+    this.detailsRenderer.setTemplateContext(context);
+  }
+
+  /**
+   * @param {LH.ReportResult.Category} category
+   * @param {Record<string, LH.Result.ReportGroup>} groupDefinitions
+   * @return {DocumentFragment}
+   */
+  renderScoreGauge(category, groupDefinitions) { // eslint-disable-line no-unused-vars
+    const tmpl = this.dom.cloneTemplate('#tmpl-lh-gauge', this.templateContext);
+    const wrapper = /** @type {HTMLAnchorElement} */ (this.dom.find('.lh-gauge__wrapper', tmpl));
+    wrapper.href = `#${category.id}`;
+    wrapper.classList.add(`lh-gauge__wrapper--${Util.calculateRating(category.score)}`);
+
+    if (Util.isPluginCategory(category.id)) {
+      wrapper.classList.add('lh-gauge__wrapper--plugin');
+    }
+
+    // Cast `null` to 0
+    const numericScore = Number(category.score);
+    const gauge = this.dom.find('.lh-gauge', tmpl);
+    // 352 is ~= 2 * Math.PI * gauge radius (56)
+    // https://codepen.io/xgad/post/svg-radial-progress-meters
+    // score of 50: `stroke-dasharray: 176 352`;
+    /** @type {?SVGCircleElement} */
+    const gaugeArc = gauge.querySelector('.lh-gauge-arc');
+    if (gaugeArc) {
+      gaugeArc.style.strokeDasharray = `${numericScore * 352} 352`;
+    }
+
+    const scoreOutOf100 = Math.round(numericScore * 100);
+    const percentageEl = this.dom.find('.lh-gauge__percentage', tmpl);
+    percentageEl.textContent = scoreOutOf100.toString();
+    if (category.score === null) {
+      percentageEl.textContent = '?';
+      percentageEl.title = Util.UIStrings.errorLabel;
+    }
+
+    this.dom.find('.lh-gauge__label', tmpl).textContent = category.title;
+    return tmpl;
+  }
+
+  /**
+   * @param {LH.ReportResult.AuditRef} audit
+   * @return {boolean}
+   */
+  _auditHasWarning(audit) {
+    return Boolean(audit.result.warnings && audit.result.warnings.length);
+  }
+
+  /**
+   * Returns the id of the top-level clump to put this audit in.
+   * @param {LH.ReportResult.AuditRef} auditRef
+   * @return {TopLevelClumpId}
+   */
+  _getClumpIdForAuditRef(auditRef) {
+    const scoreDisplayMode = auditRef.result.scoreDisplayMode;
+    if (scoreDisplayMode === 'manual' || scoreDisplayMode === 'notApplicable') {
+      return scoreDisplayMode;
+    }
+
+    if (Util.showAsPassed(auditRef.result)) {
+      if (this._auditHasWarning(auditRef)) {
+        return 'warning';
+      } else {
+        return 'passed';
+      }
+    } else {
+      return 'failed';
+    }
+  }
+
+  /**
+   * Renders a set of top level sections (clumps), under a status of failed, warning,
+   * manual, passed, or notApplicable. The result ends up something like:
+   *
+   * failed clump
+   *   ├── audit 1 (w/o group)
+   *   ├── audit 2 (w/o group)
+   *   ├── audit group
+   *   |  ├── audit 3
+   *   |  └── audit 4
+   *   └── audit group
+   *      ├── audit 5
+   *      └── audit 6
+   * other clump (e.g. 'manual')
+   *   ├── audit 1
+   *   ├── audit 2
+   *   ├── …
+   *   ⋮
+   * @param {LH.ReportResult.Category} category
+   * @param {Object<string, LH.Result.ReportGroup>} [groupDefinitions]
+   * @return {Element}
+   */
+  render(category, groupDefinitions = {}) {
+    const element = this.dom.createElement('div', 'lh-category');
+    this.createPermalinkSpan(element, category.id);
+    element.appendChild(this.renderCategoryHeader(category, groupDefinitions));
+
+    // Top level clumps for audits, in order they will appear in the report.
+    /** @type {Map<TopLevelClumpId, Array<LH.ReportResult.AuditRef>>} */
+    const clumps = new Map();
+    clumps.set('failed', []);
+    clumps.set('warning', []);
+    clumps.set('manual', []);
+    clumps.set('passed', []);
+    clumps.set('notApplicable', []);
+
+    // Sort audits into clumps.
+    for (const auditRef of category.auditRefs) {
+      const clumpId = this._getClumpIdForAuditRef(auditRef);
+      const clump = /** @type {Array<LH.ReportResult.AuditRef>} */ (clumps.get(clumpId)); // already defined
+      clump.push(auditRef);
+      clumps.set(clumpId, clump);
+    }
+
+    // Render each clump.
+    for (const [clumpId, auditRefs] of clumps) {
+      if (auditRefs.length === 0) continue;
+
+      if (clumpId === 'failed') {
+        const clumpElem = this.renderUnexpandableClump(auditRefs, groupDefinitions);
+        clumpElem.classList.add(`lh-clump--failed`);
+        element.appendChild(clumpElem);
+        continue;
+      }
+
+      const description = clumpId === 'manual' ? category.manualDescription : undefined;
+      const clumpElem = this.renderClump(clumpId, {auditRefs, description});
+      element.appendChild(clumpElem);
+    }
+
+    return element;
+  }
+
+  /**
+   * Create a non-semantic span used for hash navigation of categories
+   * @param {Element} element
+   * @param {string} id
+   */
+  createPermalinkSpan(element, id) {
+    const permalinkEl = this.dom.createChildOf(element, 'span', 'lh-permalink');
+    permalinkEl.id = id;
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = CategoryRenderer;
+} else {
+  self.CategoryRenderer = CategoryRenderer;
+}
+;
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* globals self, Util, CategoryRenderer */
+
+/** @typedef {import('./dom.js')} DOM */
+
+class PerformanceCategoryRenderer extends CategoryRenderer {
+  /**
+   * @param {LH.ReportResult.AuditRef} audit
+   * @return {Element}
+   */
+  _renderMetric(audit) {
+    const tmpl = this.dom.cloneTemplate('#tmpl-lh-metric', this.templateContext);
+    const element = this.dom.find('.lh-metric', tmpl);
+    element.id = audit.result.id;
+    const rating = Util.calculateRating(audit.result.score, audit.result.scoreDisplayMode);
+    element.classList.add(`lh-metric--${rating}`);
+
+    const titleEl = this.dom.find('.lh-metric__title', tmpl);
+    titleEl.textContent = audit.result.title;
+
+    const valueEl = this.dom.find('.lh-metric__value', tmpl);
+    valueEl.textContent = audit.result.displayValue || '';
+
+    const descriptionEl = this.dom.find('.lh-metric__description', tmpl);
+    descriptionEl.appendChild(this.dom.convertMarkdownLinkSnippets(audit.result.description));
+
+    if (audit.result.scoreDisplayMode === 'error') {
+      descriptionEl.textContent = '';
+      valueEl.textContent = 'Error!';
+      const tooltip = this.dom.createChildOf(descriptionEl, 'span');
+      tooltip.textContent = audit.result.errorMessage || 'Report error: no metric information';
+    }
+
+    return element;
+  }
+
+  /**
+   * @param {LH.ReportResult.AuditRef} audit
+   * @param {number} scale
+   * @return {Element}
+   */
+  _renderOpportunity(audit, scale) {
+    const oppTmpl = this.dom.cloneTemplate('#tmpl-lh-opportunity', this.templateContext);
+    const element = this.populateAuditValues(audit, oppTmpl);
+    element.id = audit.result.id;
+
+    if (!audit.result.details || audit.result.scoreDisplayMode === 'error') {
+      return element;
+    }
+    const details = audit.result.details;
+    if (details.type !== 'opportunity') {
+      return element;
+    }
+
+    // Overwrite the displayValue with opportunity's wastedMs
+    const displayEl = this.dom.find('.lh-audit__display-text', element);
+    const sparklineWidthPct = `${details.overallSavingsMs / scale * 100}%`;
+    this.dom.find('.lh-sparkline__bar', element).style.width = sparklineWidthPct;
+    displayEl.textContent = Util.formatSeconds(details.overallSavingsMs, 0.01);
+
+    // Set [title] tooltips
+    if (audit.result.displayValue) {
+      const displayValue = audit.result.displayValue;
+      this.dom.find('.lh-load-opportunity__sparkline', element).title = displayValue;
+      displayEl.title = displayValue;
+    }
+
+    return element;
+  }
+
+  /**
+   * Get an audit's wastedMs to sort the opportunity by, and scale the sparkline width
+   * Opportunities with an error won't have a details object, so MIN_VALUE is returned to keep any
+   * erroring opportunities last in sort order.
+   * @param {LH.ReportResult.AuditRef} audit
+   * @return {number}
+   */
+  _getWastedMs(audit) {
+    if (audit.result.details && audit.result.details.type === 'opportunity') {
+      const details = audit.result.details;
+      if (typeof details.overallSavingsMs !== 'number') {
+        throw new Error('non-opportunity details passed to _getWastedMs');
+      }
+      return details.overallSavingsMs;
+    } else {
+      return Number.MIN_VALUE;
+    }
+  }
+
+  /**
+   * @param {LH.ReportResult.Category} category
+   * @param {Object<string, LH.Result.ReportGroup>} groups
+   * @param {'PSI'=} environment 'PSI' and undefined are the only valid values
+   * @return {Element}
+   * @override
+   */
+  render(category, groups, environment) {
+    const element = this.dom.createElement('div', 'lh-category');
+    if (environment === 'PSI') {
+      const gaugeEl = this.dom.createElement('div', 'lh-score__gauge');
+      gaugeEl.appendChild(this.renderScoreGauge(category, groups));
+      element.appendChild(gaugeEl);
+    } else {
+      this.createPermalinkSpan(element, category.id);
+      element.appendChild(this.renderCategoryHeader(category, groups));
+    }
+
+    // Metrics.
+    const metricAuditsEl = this.renderAuditGroup(groups.metrics);
+
+    // Metric descriptions toggle.
+    const toggleTmpl = this.dom.cloneTemplate('#tmpl-lh-metrics-toggle', this.templateContext);
+    const _toggleEl = this.dom.find('.lh-metrics-toggle', toggleTmpl);
+    metricAuditsEl.append(..._toggleEl.childNodes);
+
+    const metricAudits = category.auditRefs.filter(audit => audit.group === 'metrics');
+    const keyMetrics = metricAudits.filter(a => a.weight >= 3);
+    const otherMetrics = metricAudits.filter(a => a.weight < 3);
+
+    const metricsBoxesEl = this.dom.createChildOf(metricAuditsEl, 'div', 'lh-columns');
+    const metricsColumn1El = this.dom.createChildOf(metricsBoxesEl, 'div', 'lh-column');
+    const metricsColumn2El = this.dom.createChildOf(metricsBoxesEl, 'div', 'lh-column');
+
+    keyMetrics.forEach(item => {
+      metricsColumn1El.appendChild(this._renderMetric(item));
+    });
+    otherMetrics.forEach(item => {
+      metricsColumn2El.appendChild(this._renderMetric(item));
+    });
+
+    // 'Values are estimated and may vary' is used as the category description for PSI
+    if (environment !== 'PSI') {
+      const estValuesEl = this.dom.createChildOf(metricAuditsEl, 'div', 'lh-metrics__disclaimer');
+      const disclaimerEl = this.dom.convertMarkdownLinkSnippets(Util.UIStrings.varianceDisclaimer);
+      estValuesEl.appendChild(disclaimerEl);
+    }
+
+    metricAuditsEl.classList.add('lh-audit-group--metrics');
+    element.appendChild(metricAuditsEl);
+
+    // Filmstrip
+    const timelineEl = this.dom.createChildOf(element, 'div', 'lh-filmstrip-container');
+    const thumbnailAudit = category.auditRefs.find(audit => audit.id === 'screenshot-thumbnails');
+    const thumbnailResult = thumbnailAudit && thumbnailAudit.result;
+    if (thumbnailResult && thumbnailResult.details) {
+      timelineEl.id = thumbnailResult.id;
+      const filmstripEl = this.detailsRenderer.render(thumbnailResult.details);
+      filmstripEl && timelineEl.appendChild(filmstripEl);
+    }
+
+    // Budgets
+    const budgetAudit = category.auditRefs.find(audit => audit.id === 'performance-budget');
+    if (budgetAudit && budgetAudit.result.details) {
+      const table = this.detailsRenderer.render(budgetAudit.result.details);
+      if (table) {
+        table.id = budgetAudit.id;
+        table.classList.add('lh-audit');
+        const budgetsGroupEl = this.renderAuditGroup(groups.budgets);
+        budgetsGroupEl.appendChild(table);
+        budgetsGroupEl.classList.add('lh-audit-group--budgets');
+        element.appendChild(budgetsGroupEl);
+      }
+    }
+
+    // Opportunities
+    const opportunityAudits = category.auditRefs
+        .filter(audit => audit.group === 'load-opportunities' && !Util.showAsPassed(audit.result))
+        .sort((auditA, auditB) => this._getWastedMs(auditB) - this._getWastedMs(auditA));
+
+    if (opportunityAudits.length) {
+      // Scale the sparklines relative to savings, minimum 2s to not overstate small savings
+      const minimumScale = 2000;
+      const wastedMsValues = opportunityAudits.map(audit => this._getWastedMs(audit));
+      const maxWaste = Math.max(...wastedMsValues);
+      const scale = Math.max(Math.ceil(maxWaste / 1000) * 1000, minimumScale);
+      const groupEl = this.renderAuditGroup(groups['load-opportunities']);
+      const tmpl = this.dom.cloneTemplate('#tmpl-lh-opportunity-header', this.templateContext);
+
+      this.dom.find('.lh-load-opportunity__col--one', tmpl).textContent =
+        Util.UIStrings.opportunityResourceColumnLabel;
+      this.dom.find('.lh-load-opportunity__col--two', tmpl).textContent =
+        Util.UIStrings.opportunitySavingsColumnLabel;
+
+      const headerEl = this.dom.find('.lh-load-opportunity__header', tmpl);
+      groupEl.appendChild(headerEl);
+      opportunityAudits.forEach(item => groupEl.appendChild(this._renderOpportunity(item, scale)));
+      groupEl.classList.add('lh-audit-group--load-opportunities');
+      element.appendChild(groupEl);
+    }
+
+    // Diagnostics
+    const diagnosticAudits = category.auditRefs
+        .filter(audit => audit.group === 'diagnostics' && !Util.showAsPassed(audit.result))
+        .sort((a, b) => {
+          const scoreA = a.result.scoreDisplayMode === 'informative' ? 100 : Number(a.result.score);
+          const scoreB = b.result.scoreDisplayMode === 'informative' ? 100 : Number(b.result.score);
+          return scoreA - scoreB;
+        });
+
+    if (diagnosticAudits.length) {
+      const groupEl = this.renderAuditGroup(groups['diagnostics']);
+      diagnosticAudits.forEach(item => groupEl.appendChild(this.renderAudit(item)));
+      groupEl.classList.add('lh-audit-group--diagnostics');
+      element.appendChild(groupEl);
+    }
+
+    // Passed audits
+    const passedAudits = category.auditRefs
+        .filter(audit => (audit.group === 'load-opportunities' || audit.group === 'diagnostics') &&
+            Util.showAsPassed(audit.result));
+
+    if (!passedAudits.length) return element;
+
+    const clumpOpts = {
+      auditRefs: passedAudits,
+      groupDefinitions: groups,
+    };
+    const passedElem = this.renderClump('passed', clumpOpts);
+    element.appendChild(passedElem);
+    return element;
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = PerformanceCategoryRenderer;
+} else {
+  self.PerformanceCategoryRenderer = PerformanceCategoryRenderer;
+}
+;
+/**
+ * @license
+ * Copyright 2018 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/* globals self, Util, CategoryRenderer */
+
+/**
+ * An always-increasing counter for making unique SVG ID suffixes.
+ */
+const getUniqueSuffix = (() => {
+  let svgSuffix = 0;
+  return function() {
+    return svgSuffix++;
+  };
+})();
+
+class PwaCategoryRenderer extends CategoryRenderer {
+  /**
+   * @param {LH.ReportResult.Category} category
+   * @param {Object<string, LH.Result.ReportGroup>} [groupDefinitions]
+   * @return {Element}
+   */
+  render(category, groupDefinitions = {}) {
+    const categoryElem = this.dom.createElement('div', 'lh-category');
+    this.createPermalinkSpan(categoryElem, category.id);
+    categoryElem.appendChild(this.renderCategoryHeader(category, groupDefinitions));
+
+    const auditRefs = category.auditRefs;
+
+    // Regular audits aren't split up into pass/fail/notApplicable clumps, they're
+    // all put in a top-level clump that isn't expandable/collapsible.
+    const regularAuditRefs = auditRefs.filter(ref => ref.result.scoreDisplayMode !== 'manual');
+    const auditsElem = this._renderAudits(regularAuditRefs, groupDefinitions);
+    categoryElem.appendChild(auditsElem);
+
+    // Manual audits are still in a manual clump.
+    const manualAuditRefs = auditRefs.filter(ref => ref.result.scoreDisplayMode === 'manual');
+    const manualElem = this.renderClump('manual',
+      {auditRefs: manualAuditRefs, description: category.manualDescription});
+    categoryElem.appendChild(manualElem);
+
+    return categoryElem;
+  }
+
+  /**
+   * @param {LH.ReportResult.Category} category
+   * @param {Record<string, LH.Result.ReportGroup>} groupDefinitions
+   * @return {DocumentFragment}
+   */
+  renderScoreGauge(category, groupDefinitions) {
+    // Defer to parent-gauge style if category error.
+    if (category.score === null) {
+      return super.renderScoreGauge(category, groupDefinitions);
+    }
+
+    const tmpl = this.dom.cloneTemplate('#tmpl-lh-gauge--pwa', this.templateContext);
+    const wrapper = /** @type {HTMLAnchorElement} */ (this.dom.find('.lh-gauge--pwa__wrapper',
+      tmpl));
+    wrapper.href = `#${category.id}`;
+
+    // Correct IDs in case multiple instances end up in the page.
+    const svgRoot = tmpl.querySelector('svg');
+    if (!svgRoot) throw new Error('no SVG element found in PWA score gauge template');
+    PwaCategoryRenderer._makeSvgReferencesUnique(svgRoot);
+
+    const allGroups = this._getGroupIds(category.auditRefs);
+    const passingGroupIds = this._getPassingGroupIds(category.auditRefs);
+
+    if (passingGroupIds.size === allGroups.size) {
+      wrapper.classList.add('lh-badged--all');
+    } else {
+      for (const passingGroupId of passingGroupIds) {
+        wrapper.classList.add(`lh-badged--${passingGroupId}`);
+      }
+    }
+
+    this.dom.find('.lh-gauge__label', tmpl).textContent = category.title;
+    wrapper.title = this._getGaugeTooltip(category.auditRefs, groupDefinitions);
+    return tmpl;
+  }
+
+  /**
+   * Returns the group IDs found in auditRefs.
+   * @param {Array<LH.ReportResult.AuditRef>} auditRefs
+   * @return {Set<string>}
+   */
+  _getGroupIds(auditRefs) {
+    const groupIds = auditRefs.map(ref => ref.group).filter(/** @return {g is string} */ g => !!g);
+    return new Set(groupIds);
+  }
+
+  /**
+   * Returns the group IDs whose audits are all considered passing.
+   * @param {Array<LH.ReportResult.AuditRef>} auditRefs
+   * @return {Set<string>}
+   */
+  _getPassingGroupIds(auditRefs) {
+    const uniqueGroupIds = this._getGroupIds(auditRefs);
+
+    // Remove any that have a failing audit.
+    for (const auditRef of auditRefs) {
+      if (!Util.showAsPassed(auditRef.result) && auditRef.group) {
+        uniqueGroupIds.delete(auditRef.group);
+      }
+    }
+
+    return uniqueGroupIds;
+  }
+
+  /**
+   * Returns a tooltip string summarizing group pass rates.
+   * @param {Array<LH.ReportResult.AuditRef>} auditRefs
+   * @param {Record<string, LH.Result.ReportGroup>} groupDefinitions
+   * @return {string}
+   */
+  _getGaugeTooltip(auditRefs, groupDefinitions) {
+    const groupIds = this._getGroupIds(auditRefs);
+
+    const tips = [];
+    for (const groupId of groupIds) {
+      const groupAuditRefs = auditRefs.filter(ref => ref.group === groupId);
+      const auditCount = groupAuditRefs.length;
+      const passedCount = groupAuditRefs.filter(ref => Util.showAsPassed(ref.result)).length;
+
+      const title = groupDefinitions[groupId].title;
+      tips.push(`${title}: ${passedCount}/${auditCount}`);
+    }
+
+    return tips.join(', ');
+  }
+
+  /**
+   * Render non-manual audits in groups, giving a badge to any group that has
+   * all passing audits.
+   * @param {Array<LH.ReportResult.AuditRef>} auditRefs
+   * @param {Object<string, LH.Result.ReportGroup>} groupDefinitions
+   * @return {Element}
+   */
+  _renderAudits(auditRefs, groupDefinitions) {
+    const auditsElem = this.renderUnexpandableClump(auditRefs, groupDefinitions);
+
+    // Add a 'badged' class to group if all audits in that group pass.
+    const passsingGroupIds = this._getPassingGroupIds(auditRefs);
+    for (const groupId of passsingGroupIds) {
+      const groupElem = this.dom.find(`.lh-audit-group--${groupId}`, auditsElem);
+      groupElem.classList.add('lh-badged');
+    }
+
+    return auditsElem;
+  }
+
+  /**
+   * Alters SVG id references so multiple instances of an SVG element can coexist
+   * in a single page. If `svgRoot` has a `<defs>` block, gives all elements defined
+   * in it unique ids, then updates id references (`<use xlink:href="...">`,
+   * `fill="url(#...)"`) to the altered ids in all descendents of `svgRoot`.
+   * @param {SVGElement} svgRoot
+   */
+  static _makeSvgReferencesUnique(svgRoot) {
+    const defsEl = svgRoot.querySelector('defs');
+    if (!defsEl) return;
+
+    const idSuffix = getUniqueSuffix();
+    const elementsToUpdate = defsEl.querySelectorAll('[id]');
+    for (const el of elementsToUpdate) {
+      const oldId = el.id;
+      const newId = `${oldId}-${idSuffix}`;
+      el.id = newId;
+
+      // Update all <use>s.
+      const useEls = svgRoot.querySelectorAll(`use[href="#${oldId}"]`);
+      for (const useEl of useEls) {
+        useEl.setAttribute('href', `#${newId}`);
+      }
+
+      // Update all fill="url(#...)"s.
+      const fillEls = svgRoot.querySelectorAll(`[fill="url(#${oldId})"]`);
+      for (const fillEl of fillEls) {
+        fillEl.setAttribute('fill', `url(#${newId})`);
+      }
+    }
+  }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = PwaCategoryRenderer;
+} else {
+  self.PwaCategoryRenderer = PwaCategoryRenderer;
+}
+;
+/**
+ * @license
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+/**
+ * @fileoverview The entry point for rendering the Lighthouse report based on the JSON output.
+ *    This file is injected into the report HTML along with the JSON report.
+ *
+ * Dummy text for ensuring report robustness: \u003c/script> pre$`post %%LIGHTHOUSE_JSON%%
+ */
+
+/** @typedef {import('./dom.js')} DOM */
+
+/* globals self, Util, DetailsRenderer, CategoryRenderer, PerformanceCategoryRenderer, PwaCategoryRenderer */
+
+class ReportRenderer {
+  /**
+   * @param {DOM} dom
+   */
+  constructor(dom) {
+    /** @type {DOM} */
+    this._dom = dom;
+    /** @type {ParentNode} */
+    this._templateContext = this._dom.document();
+  }
+
+  /**
+   * @param {LH.Result} result
+   * @param {Element} container Parent element to render the report into.
+   * @return {Element}
+   */
+  renderReport(result, container) {
+    // Mutate the UIStrings if necessary (while saving originals)
+    const originalUIStrings = JSON.parse(JSON.stringify(Util.UIStrings));
+
+    this._dom.setLighthouseChannel(result.configSettings.channel || 'unknown');
+
+    const report = Util.prepareReportResult(result);
+
+    container.textContent = ''; // Remove previous report.
+    container.appendChild(this._renderReport(report));
+
+    // put the UIStrings back into original state
+    Util.updateAllUIStrings(originalUIStrings);
+
+    return container;
+  }
+
+  /**
+   * Define a custom element for <templates> to be extracted from. For example:
+   *     this.setTemplateContext(new DOMParser().parseFromString(htmlStr, 'text/html'))
+   * @param {ParentNode} context
+   */
+  setTemplateContext(context) {
+    this._templateContext = context;
+  }
+
+  /**
+   * @param {LH.ReportResult} report
+   * @return {DocumentFragment}
+   */
+  _renderReportTopbar(report) {
+    const el = this._dom.cloneTemplate('#tmpl-lh-topbar', this._templateContext);
+    const metadataUrl = /** @type {HTMLAnchorElement} */ (this._dom.find('.lh-topbar__url', el));
+    metadataUrl.href = metadataUrl.textContent = report.finalUrl;
+    metadataUrl.title = report.finalUrl;
+    return el;
+  }
+
+  /**
+   * @return {DocumentFragment}
+   */
+  _renderReportHeader() {
+    const el = this._dom.cloneTemplate('#tmpl-lh-heading', this._templateContext);
+    const domFragment = this._dom.cloneTemplate('#tmpl-lh-scores-wrapper', this._templateContext);
+    const placeholder = this._dom.find('.lh-scores-wrapper-placeholder', el);
+    /** @type {HTMLDivElement} */ (placeholder.parentNode).replaceChild(domFragment, placeholder);
+    return el;
+  }
+
+  /**
+   * @param {LH.ReportResult} report
+   * @return {DocumentFragment}
+   */
+  _renderReportFooter(report) {
+    const footer = this._dom.cloneTemplate('#tmpl-lh-footer', this._templateContext);
+
+    const env = this._dom.find('.lh-env__items', footer);
+    env.id = 'runtime-settings';
+    const envValues = Util.getEnvironmentDisplayValues(report.configSettings || {});
+    [
+      {name: 'URL', description: report.finalUrl},
+      {name: 'Fetch time', description: Util.formatDateTime(report.fetchTime)},
+      ...envValues,
+      {name: 'User agent (host)', description: report.userAgent},
+      {name: 'User agent (network)', description: report.environment &&
+        report.environment.networkUserAgent},
+      {name: 'CPU/Memory Power', description: report.environment &&
+        report.environment.benchmarkIndex.toFixed(0)},
+    ].forEach(runtime => {
+      if (!runtime.description) return;
+
+      const item = this._dom.cloneTemplate('#tmpl-lh-env__items', env);
+      this._dom.find('.lh-env__name', item).textContent = runtime.name;
+      this._dom.find('.lh-env__description', item).textContent = runtime.description;
+      env.appendChild(item);
+    });
+
+    this._dom.find('.lh-footer__version', footer).textContent = report.lighthouseVersion;
+    return footer;
+  }
+
+  /**
+   * Returns a div with a list of top-level warnings, or an empty div if no warnings.
+   * @param {LH.ReportResult} report
+   * @return {Node}
+   */
+  _renderReportWarnings(report) {
+    if (!report.runWarnings || report.runWarnings.length === 0) {
+      return this._dom.createElement('div');
+    }
+
+    const container = this._dom.cloneTemplate('#tmpl-lh-warnings--toplevel', this._templateContext);
+    const message = this._dom.find('.lh-warnings__msg', container);
+    message.textContent = Util.UIStrings.toplevelWarningsMessage;
+
+    const warnings = this._dom.find('ul', container);
+    for (const warningString of report.runWarnings) {
+      const warning = warnings.appendChild(this._dom.createElement('li'));
+      warning.textContent = warningString;
+    }
+
+    return container;
+  }
+
+  /**
+   * @param {LH.ReportResult} report
+   * @param {CategoryRenderer} categoryRenderer
+   * @param {Record<string, CategoryRenderer>} specificCategoryRenderers
+   * @return {DocumentFragment[]}
+   */
+  _renderScoreGauges(report, categoryRenderer, specificCategoryRenderers) {
+    // Group gauges in this order: default, pwa, plugins.
+    const defaultGauges = [];
+    const customGauges = []; // PWA.
+    const pluginGauges = [];
+
+    for (const category of Object.values(report.categories)) {
+      const renderer = specificCategoryRenderers[category.id] || categoryRenderer;
+      const categoryGauge = renderer.renderScoreGauge(category, report.categoryGroups || {});
+
+      if (Util.isPluginCategory(category.id)) {
+        pluginGauges.push(categoryGauge);
+      } else if (renderer.renderScoreGauge === categoryRenderer.renderScoreGauge) {
+        // The renderer for default categories is just the default CategoryRenderer.
+        // If the functions are equal, then renderer is an instance of CategoryRenderer.
+        // For example, the PWA category uses PwaCategoryRenderer, which overrides
+        // CategoryRenderer.renderScoreGauge, so it would fail this check and be placed
+        // in the customGauges bucket.
+        defaultGauges.push(categoryGauge);
+      } else {
+        customGauges.push(categoryGauge);
+      }
+    }
+
+    return [...defaultGauges, ...customGauges, ...pluginGauges];
+  }
+
+  /**
+   * @param {LH.ReportResult} report
+   * @return {DocumentFragment}
+   */
+  _renderReport(report) {
+    const detailsRenderer = new DetailsRenderer(this._dom);
+    const categoryRenderer = new CategoryRenderer(this._dom, detailsRenderer);
+    categoryRenderer.setTemplateContext(this._templateContext);
+
+    /** @type {Record<string, CategoryRenderer>} */
+    const specificCategoryRenderers = {
+      performance: new PerformanceCategoryRenderer(this._dom, detailsRenderer),
+      pwa: new PwaCategoryRenderer(this._dom, detailsRenderer),
+    };
+    Object.values(specificCategoryRenderers).forEach(renderer => {
+      renderer.setTemplateContext(this._templateContext);
+    });
+
+    const headerContainer = this._dom.createElement('div');
+    headerContainer.appendChild(this._renderReportHeader());
+
+    const reportContainer = this._dom.createElement('div', 'lh-container');
+    const reportSection = this._dom.createElement('div', 'lh-report');
+    reportSection.appendChild(this._renderReportWarnings(report));
+
+    let scoreHeader;
+    const isSoloCategory = Object.keys(report.categories).length === 1;
+    if (!isSoloCategory) {
+      scoreHeader = this._dom.createElement('div', 'lh-scores-header');
+    } else {
+      headerContainer.classList.add('lh-header--solo-category');
+    }
+
+    if (scoreHeader) {
+      const scoreScale = this._dom.cloneTemplate('#tmpl-lh-scorescale', this._templateContext);
+      const scoresContainer = this._dom.find('.lh-scores-container', headerContainer);
+      scoreHeader.append(
+        ...this._renderScoreGauges(report, categoryRenderer, specificCategoryRenderers));
+      scoresContainer.appendChild(scoreHeader);
+      scoresContainer.appendChild(scoreScale);
+
+      const stickyHeader = this._dom.createElement('div', 'lh-sticky-header');
+      stickyHeader.append(
+        ...this._renderScoreGauges(report, categoryRenderer, specificCategoryRenderers));
+      reportContainer.appendChild(stickyHeader);
+    }
+
+    const categories = reportSection.appendChild(this._dom.createElement('div', 'lh-categories'));
+    for (const category of Object.values(report.categories)) {
+      const renderer = specificCategoryRenderers[category.id] || categoryRenderer;
+      // .lh-category-wrapper is full-width and provides horizontal rules between categories.
+      // .lh-category within has the max-width: var(--report-width);
+      const wrapper = renderer.dom.createChildOf(categories, 'div', 'lh-category-wrapper');
+      wrapper.appendChild(renderer.render(category, report.categoryGroups));
+    }
+
+    const reportFragment = this._dom.createFragment();
+    const topbarDocumentFragment = this._renderReportTopbar(report);
+
+    reportFragment.appendChild(topbarDocumentFragment);
+    reportFragment.appendChild(reportContainer);
+    reportContainer.appendChild(headerContainer);
+    reportContainer.appendChild(reportSection);
+    reportSection.appendChild(this._renderReportFooter(report));
+
+    return reportFragment;
+  }
+}
+
+/** @type {LH.I18NRendererStrings} */
+ReportRenderer._UIStringsStash = {};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = ReportRenderer;
+} else {
+  self.ReportRenderer = ReportRenderer;
+}
+
+  //# sourceURL=compiled-reportrenderer.js
+  </script>
+  <script>window.__LIGHTHOUSE_JSON__ = {"userAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/80.0.3987.0 Safari/537.36","environment":{"networkUserAgent":"","hostUserAgent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/80.0.3987.0 Safari/537.36","benchmarkIndex":92},"lighthouseVersion":"5.6.0","fetchTime":"2020-03-12T20:05:26.605Z","requestedUrl":"https://example.com/","finalUrl":"https://example.com/","runWarnings":["Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests. (Details: net::ERR_CERT_AUTHORITY_INVALID)"],"runtimeError":{"code":"FAILED_DOCUMENT_REQUEST","message":"Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests. (Details: net::ERR_CERT_AUTHORITY_INVALID)"},"audits":{"is-on-https":{"id":"is-on-https","title":"Uses HTTPS","description":"All sites should be protected with HTTPS, even ones that don't handle sensitive data. HTTPS prevents intruders from tampering with or passively listening in on the communications between your app and your users, and is a prerequisite for HTTP/2 and many new web platform APIs. [Learn more](https://web.dev/is-on-https).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"redirects-http":{"id":"redirects-http","title":"Redirects HTTP traffic to HTTPS","description":"If you've already set up HTTPS, make sure that you redirect all HTTP traffic to HTTPS in order to enable secure web features for all your users. [Learn more](https://web.dev/redirects-http).","score":null,"scoreDisplayMode":"error","errorMessage":"Required HTTPRedirect gatherer did not run."},"service-worker":{"id":"service-worker","title":"Registers a service worker that controls page and `start_url`","description":"The service worker is the technology that enables your app to use many Progressive Web App features, such as offline, add to homescreen, and push notifications. [Learn more](https://web.dev/service-worker).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ServiceWorker gatherer did not run."},"works-offline":{"id":"works-offline","title":"Current page responds with a 200 when offline","description":"If you're building a Progressive Web App, consider using a service worker so that your app can work offline. [Learn more](https://web.dev/works-offline).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Offline gatherer did not run."},"viewport":{"id":"viewport","title":"Has a `\u003cmeta name=\"viewport\">` tag with `width` or `initial-scale`","description":"Add a `\u003cmeta name=\"viewport\">` tag to optimize your app for mobile screens. [Learn more](https://web.dev/viewport).","score":null,"scoreDisplayMode":"error","errorMessage":"Required MetaElements gatherer did not run."},"without-javascript":{"id":"without-javascript","title":"Contains some content when JavaScript is not available","description":"Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app. [Learn more](https://web.dev/without-javascript).","score":null,"scoreDisplayMode":"error","errorMessage":"Required HTMLWithoutJavaScript gatherer did not run."},"first-contentful-paint":{"id":"first-contentful-paint","title":"First Contentful Paint","description":"First Contentful Paint marks the time at which the first text or image is painted. [Learn more](https://web.dev/first-contentful-paint).","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"first-meaningful-paint":{"id":"first-meaningful-paint","title":"First Meaningful Paint","description":"First Meaningful Paint measures when the primary content of a page is visible. [Learn more](https://web.dev/first-meaningful-paint).","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"load-fast-enough-for-pwa":{"id":"load-fast-enough-for-pwa","title":"Page load is fast enough on mobile networks","description":"A fast page load over a cellular network ensures a good mobile user experience. [Learn more](https://web.dev/load-fast-enough-for-pwa).","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"speed-index":{"id":"speed-index","title":"Speed Index","description":"Speed Index shows how quickly the contents of a page are visibly populated. [Learn more](https://web.dev/speed-index).","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"screenshot-thumbnails":{"id":"screenshot-thumbnails","title":"Screenshot Thumbnails","description":"This is what the load of your site looked like.","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"final-screenshot":{"id":"final-screenshot","title":"Final Screenshot","description":"The last screenshot captured of the pageload.","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"estimated-input-latency":{"id":"estimated-input-latency","title":"Estimated Input Latency","description":"Estimated Input Latency is an estimate of how long your app takes to respond to user input, in milliseconds, during the busiest 5s window of page load. If your latency is higher than 50 ms, users may perceive your app as laggy. [Learn more](https://web.dev/estimated-input-latency).","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"total-blocking-time":{"id":"total-blocking-time","title":"Total Blocking Time","description":"Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds.","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"max-potential-fid":{"id":"max-potential-fid","title":"Max Potential First Input Delay","description":"The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. [Learn more](https://developers.google.com/web/updates/2018/05/first-input-delay).","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"errors-in-console":{"id":"errors-in-console","title":"No browser errors logged to the console","description":"Errors logged to the console indicate unresolved problems. They can come from network request failures and other browser concerns. [Learn more](https://web.dev/errors-in-console)","score":null,"scoreDisplayMode":"error","errorMessage":"Required ConsoleMessages gatherer did not run."},"time-to-first-byte":{"id":"time-to-first-byte","title":"Server response times are low (TTFB)","description":"Time To First Byte identifies the time at which your server sends a response. [Learn more](https://web.dev/time-to-first-byte).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"first-cpu-idle":{"id":"first-cpu-idle","title":"First CPU Idle","description":"First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  [Learn more](https://web.dev/first-cpu-idle).","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"interactive":{"id":"interactive","title":"Time to Interactive","description":"Time to interactive is the amount of time it takes for the page to become fully interactive. [Learn more](https://web.dev/interactive).","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"user-timings":{"id":"user-timings","title":"User Timing marks and measures","description":"Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more](https://web.dev/user-timings).","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"critical-request-chains":{"id":"critical-request-chains","title":"Avoid chaining critical requests","description":"The Critical Request Chains below show you what resources are loaded with a high priority. Consider reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load. [Learn more](https://web.dev/critical-request-chains).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"redirects":{"id":"redirects","title":"Avoid multiple page redirects","description":"Redirects introduce additional delays before the page can be loaded. [Learn more](https://web.dev/redirects).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"installable-manifest":{"id":"installable-manifest","title":"Web app manifest does not meet the installability requirements","description":"Browsers can proactively prompt users to add your app to their homescreen, which can lead to higher engagement. [Learn more](https://web.dev/installable-manifest).","score":0,"scoreDisplayMode":"binary","explanation":"Failures: No manifest was fetched.","details":{"type":"debugdata","items":[{"failures":["No manifest was fetched"],"isParseFailure":true,"parseFailureReason":"No manifest was fetched"}]}},"apple-touch-icon":{"id":"apple-touch-icon","title":"Provides a valid `apple-touch-icon`","description":"For ideal appearance on iOS when users add a progressive web app to the home screen, define an `apple-touch-icon`. It must point to a non-transparent 192px (or 180px) square PNG. [Learn More](https://web.dev/apple-touch-icon/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required LinkElements gatherer did not run."},"splash-screen":{"id":"splash-screen","title":"Is not configured for a custom splash screen","description":"A themed splash screen ensures a high-quality experience when users launch your app from their homescreens. [Learn more](https://web.dev/splash-screen).","score":0,"scoreDisplayMode":"binary","explanation":"Failures: No manifest was fetched.","details":{"type":"debugdata","items":[{"failures":["No manifest was fetched"],"isParseFailure":true,"parseFailureReason":"No manifest was fetched"}]}},"themed-omnibox":{"id":"themed-omnibox","title":"Sets a theme color for the address bar.","description":"The browser address bar can be themed to match your site. [Learn more](https://web.dev/themed-omnibox).","score":null,"scoreDisplayMode":"error","errorMessage":"Required MetaElements gatherer did not run."},"content-width":{"id":"content-width","title":"Content is sized correctly for the viewport","description":"If the width of your app's content doesn't match the width of the viewport, your app might not be optimized for mobile screens. [Learn more](https://web.dev/content-width).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ViewportDimensions gatherer did not run."},"image-aspect-ratio":{"id":"image-aspect-ratio","title":"Displays images with correct aspect ratio","description":"Image display dimensions should match natural aspect ratio. [Learn more](https://web.dev/image-aspect-ratio).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ImageElements gatherer did not run."},"deprecations":{"id":"deprecations","title":"Avoids deprecated APIs","description":"Deprecated APIs will eventually be removed from the browser. [Learn more](https://web.dev/deprecations).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ConsoleMessages gatherer did not run."},"mainthread-work-breakdown":{"id":"mainthread-work-breakdown","title":"Minimizes main-thread work","description":"Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn more](https://web.dev/mainthread-work-breakdown)","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"bootup-time":{"id":"bootup-time","title":"JavaScript execution time","description":"Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn more](https://web.dev/bootup-time).","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"uses-rel-preload":{"id":"uses-rel-preload","title":"Preload key requests","description":"Consider using `\u003clink rel=preload>` to prioritize fetching resources that are currently requested later in page load. [Learn more](https://web.dev/uses-rel-preload).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"uses-rel-preconnect":{"id":"uses-rel-preconnect","title":"Preconnect to required origins","description":"Consider adding `preconnect` or `dns-prefetch` resource hints to establish early connections to important third-party origins. [Learn more](https://web.dev/uses-rel-preconnect).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"font-display":{"id":"font-display","title":"All text remains visible during webfont loads","description":"Leverage the font-display CSS feature to ensure text is user-visible while webfonts are loading. [Learn more](https://web.dev/font-display).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"diagnostics":{"id":"diagnostics","title":"Diagnostics","description":"Collection of useful page vitals.","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"network-requests":{"id":"network-requests","title":"Network Requests","description":"Lists the network requests that were made during page load.","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"network-rtt":{"id":"network-rtt","title":"Network Round Trip Times","description":"Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more](https://hpbn.co/primer-on-latency-and-bandwidth/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"network-server-latency":{"id":"network-server-latency","title":"Server Backend Latencies","description":"Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"main-thread-tasks":{"id":"main-thread-tasks","title":"Tasks","description":"Lists the toplevel main thread tasks that executed during page load.","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"metrics":{"id":"metrics","title":"Metrics","description":"Collects all available metrics.","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"offline-start-url":{"id":"offline-start-url","title":"`start_url` responds with a 200 when offline","description":"A service worker enables your web app to be reliable in unpredictable network conditions. [Learn more](https://web.dev/offline-start-url).","score":null,"scoreDisplayMode":"error","errorMessage":"Required StartUrl gatherer did not run."},"performance-budget":{"id":"performance-budget","title":"Performance budget","description":"Keep the quantity and size of network requests under the targets set by the provided performance budget. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/budgets).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"resource-summary":{"id":"resource-summary","title":"Keep request counts low and transfer sizes small","description":"To set budgets for the quantity and size of page resources, add a budget.json file. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/budgets).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"third-party-summary":{"id":"third-party-summary","title":"Minimize third-party usage","description":"Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and try to load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required traces gatherer did not run."},"pwa-cross-browser":{"id":"pwa-cross-browser","title":"Site works cross-browser","description":"To reach the most number of users, sites should work across every major browser. [Learn more](https://web.dev/pwa-cross-browser).","score":null,"scoreDisplayMode":"manual"},"pwa-page-transitions":{"id":"pwa-page-transitions","title":"Page transitions don't feel like they block on the network","description":"Transitions should feel snappy as you tap around, even on a slow network. This experience is key to a user's perception of performance. [Learn more](https://web.dev/pwa-page-transitions).","score":null,"scoreDisplayMode":"manual"},"pwa-each-page-has-url":{"id":"pwa-each-page-has-url","title":"Each page has a URL","description":"Ensure individual pages are deep linkable via URL and that URLs are unique for the purpose of shareability on social media. [Learn more](https://web.dev/pwa-each-page-has-url).","score":null,"scoreDisplayMode":"manual"},"accesskeys":{"id":"accesskeys","title":"`[accesskey]` values are unique","description":"Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://web.dev/accesskeys/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"aria-allowed-attr":{"id":"aria-allowed-attr","title":"`[aria-*]` attributes match their roles","description":"Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes. [Learn more](https://web.dev/aria-allowed-attr/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"aria-required-attr":{"id":"aria-required-attr","title":"`[role]`s have all required `[aria-*]` attributes","description":"Some ARIA roles have required attributes that describe the state of the element to screen readers. [Learn more](https://web.dev/aria-required-attr/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"aria-required-children":{"id":"aria-required-children","title":"Elements with an ARIA `[role]` that require children to contain a specific `[role]` have all required children.","description":"Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-children/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"aria-required-parent":{"id":"aria-required-parent","title":"`[role]`s are contained by their required parent element","description":"Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-parent/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"aria-roles":{"id":"aria-roles","title":"`[role]` values are valid","description":"ARIA roles must have valid values in order to perform their intended accessibility functions. [Learn more](https://web.dev/aria-roles/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"aria-valid-attr-value":{"id":"aria-valid-attr-value","title":"`[aria-*]` attributes have valid values","description":"Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid values. [Learn more](https://web.dev/aria-valid-attr-value/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"aria-valid-attr":{"id":"aria-valid-attr","title":"`[aria-*]` attributes are valid and not misspelled","description":"Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid names. [Learn more](https://web.dev/aria-valid-attr/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"audio-caption":{"id":"audio-caption","title":"`\u003caudio>` elements contain a `\u003ctrack>` element with `[kind=\"captions\"]`","description":"Captions make audio elements usable for deaf or hearing-impaired users, providing critical information such as who is talking, what they're saying, and other non-speech information. [Learn more](https://web.dev/audio-caption/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"button-name":{"id":"button-name","title":"Buttons have an accessible name","description":"When a button doesn't have an accessible name, screen readers announce it as \"button\", making it unusable for users who rely on screen readers. [Learn more](https://web.dev/button-name/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"bypass":{"id":"bypass","title":"The page contains a heading, skip link, or landmark region","description":"Adding ways to bypass repetitive content lets keyboard users navigate the page more efficiently. [Learn more](https://web.dev/bypass/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"color-contrast":{"id":"color-contrast","title":"Background and foreground colors have a sufficient contrast ratio","description":"Low-contrast text is difficult or impossible for many users to read. [Learn more](https://web.dev/color-contrast/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"definition-list":{"id":"definition-list","title":"`\u003cdl>`'s contain only properly-ordered `\u003cdt>` and `\u003cdd>` groups, `\u003cscript>` or `\u003ctemplate>` elements.","description":"When definition lists are not properly marked up, screen readers may produce confusing or inaccurate output. [Learn more](https://web.dev/definition-list/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"dlitem":{"id":"dlitem","title":"Definition list items are wrapped in `\u003cdl>` elements","description":"Definition list items (`\u003cdt>` and `\u003cdd>`) must be wrapped in a parent `\u003cdl>` element to ensure that screen readers can properly announce them. [Learn more](https://web.dev/dlitem/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"document-title":{"id":"document-title","title":"Document has a `\u003ctitle>` element","description":"The title gives screen reader users an overview of the page, and search engine users rely on it heavily to determine if a page is relevant to their search. [Learn more](https://web.dev/document-title/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"duplicate-id":{"id":"duplicate-id","title":"`[id]` attributes on the page are unique","description":"The value of an id attribute must be unique to prevent other instances from being overlooked by assistive technologies. [Learn more](https://web.dev/duplicate-id/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"frame-title":{"id":"frame-title","title":"`\u003cframe>` or `\u003ciframe>` elements have a title","description":"Screen reader users rely on frame titles to describe the contents of frames. [Learn more](https://web.dev/frame-title/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"html-has-lang":{"id":"html-has-lang","title":"`\u003chtml>` element has a `[lang]` attribute","description":"If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. [Learn more](https://web.dev/html-has-lang/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"html-lang-valid":{"id":"html-lang-valid","title":"`\u003chtml>` element has a valid value for its `[lang]` attribute","description":"Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) helps screen readers announce text properly. [Learn more](https://web.dev/html-lang-valid/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"image-alt":{"id":"image-alt","title":"Image elements have `[alt]` attributes","description":"Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute. [Learn more](https://web.dev/image-alt/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"input-image-alt":{"id":"input-image-alt","title":"`\u003cinput type=\"image\">` elements have `[alt]` text","description":"When an image is being used as an `\u003cinput>` button, providing alternative text can help screen reader users understand the purpose of the button. [Learn more](https://web.dev/input-image-alt/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"label":{"id":"label","title":"Form elements have associated labels","description":"Labels ensure that form controls are announced properly by assistive technologies, like screen readers. [Learn more](https://web.dev/label/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"layout-table":{"id":"layout-table","title":"Presentational `\u003ctable>` elements avoid using `\u003cth>`, `\u003ccaption>` or the `[summary]` attribute.","description":"A table being used for layout purposes should not include data elements, such as the th or caption elements or the summary attribute, because this can create a confusing experience for screen reader users. [Learn more](https://web.dev/layout-table/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"link-name":{"id":"link-name","title":"Links have a discernible name","description":"Link text (and alternate text for images, when used as links) that is discernible, unique, and focusable improves the navigation experience for screen reader users. [Learn more](https://web.dev/link-name/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"list":{"id":"list","title":"Lists contain only `\u003cli>` elements and script supporting elements (`\u003cscript>` and `\u003ctemplate>`).","description":"Screen readers have a specific way of announcing lists. Ensuring proper list structure aids screen reader output. [Learn more](https://web.dev/list/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"listitem":{"id":"listitem","title":"List items (`\u003cli>`) are contained within `\u003cul>` or `\u003col>` parent elements","description":"Screen readers require list items (`\u003cli>`) to be contained within a parent `\u003cul>` or `\u003col>` to be announced properly. [Learn more](https://web.dev/listitem/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"meta-refresh":{"id":"meta-refresh","title":"The document does not use `\u003cmeta http-equiv=\"refresh\">`","description":"Users do not expect a page to refresh automatically, and doing so will move focus back to the top of the page. This may create a frustrating or confusing experience. [Learn more](https://web.dev/meta-refresh/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"meta-viewport":{"id":"meta-viewport","title":"`[user-scalable=\"no\"]` is not used in the `\u003cmeta name=\"viewport\">` element and the `[maximum-scale]` attribute is not less than 5.","description":"Disabling zooming is problematic for users with low vision who rely on screen magnification to properly see the contents of a web page. [Learn more](https://web.dev/meta-viewport/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"object-alt":{"id":"object-alt","title":"`\u003cobject>` elements have `[alt]` text","description":"Screen readers cannot translate non-text content. Adding alt text to `\u003cobject>` elements helps screen readers convey meaning to users. [Learn more](https://web.dev/object-alt/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"tabindex":{"id":"tabindex","title":"No element has a `[tabindex]` value greater than 0","description":"A value greater than 0 implies an explicit navigation ordering. Although technically valid, this often creates frustrating experiences for users who rely on assistive technologies. [Learn more](https://web.dev/tabindex/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"td-headers-attr":{"id":"td-headers-attr","title":"Cells in a `\u003ctable>` element that use the `[headers]` attribute refer to table cells within the same table.","description":"Screen readers have features to make navigating tables easier. Ensuring `\u003ctd>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://web.dev/td-headers-attr/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"th-has-data-cells":{"id":"th-has-data-cells","title":"`\u003cth>` elements and elements with `[role=\"columnheader\"/\"rowheader\"]` have data cells they describe.","description":"Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://web.dev/th-has-data-cells/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"valid-lang":{"id":"valid-lang","title":"`[lang]` attributes have a valid value","description":"Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) on elements helps ensure that text is pronounced correctly by a screen reader. [Learn more](https://web.dev/valid-lang/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"video-caption":{"id":"video-caption","title":"`\u003cvideo>` elements contain a `\u003ctrack>` element with `[kind=\"captions\"]`","description":"When a video provides a caption it is easier for deaf and hearing impaired users to access its information. [Learn more](https://web.dev/video-caption/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"video-description":{"id":"video-description","title":"`\u003cvideo>` elements contain a `\u003ctrack>` element with `[kind=\"description\"]`","description":"Audio descriptions provide relevant information for videos that dialogue cannot, such as facial expressions and scenes. [Learn more](https://web.dev/video-description/).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Accessibility gatherer did not run."},"custom-controls-labels":{"id":"custom-controls-labels","title":"Custom controls have associated labels","description":"Custom interactive controls have associated labels, provided by aria-label or aria-labelledby. [Learn more](https://web.dev/custom-controls-labels/).","score":null,"scoreDisplayMode":"manual"},"custom-controls-roles":{"id":"custom-controls-roles","title":"Custom controls have ARIA roles","description":"Custom interactive controls have appropriate ARIA roles. [Learn more](https://web.dev/custom-control-roles/).","score":null,"scoreDisplayMode":"manual"},"focus-traps":{"id":"focus-traps","title":"User focus is not accidentally trapped in a region","description":"A user can tab into and out of any control or region without accidentally trapping their focus. [Learn more](https://web.dev/focus-traps/).","score":null,"scoreDisplayMode":"manual"},"focusable-controls":{"id":"focusable-controls","title":"Interactive controls are keyboard focusable","description":"Custom interactive controls are keyboard focusable and display a focus indicator. [Learn more](https://web.dev/focusable-controls/).","score":null,"scoreDisplayMode":"manual"},"heading-levels":{"id":"heading-levels","title":"Headings don't skip levels","description":"Headings are used to create an outline for the page and heading levels are not skipped. [Learn more](https://web.dev/heading-levels/).","score":null,"scoreDisplayMode":"manual"},"interactive-element-affordance":{"id":"interactive-element-affordance","title":"Interactive elements indicate their purpose and state","description":"Interactive elements, such as links and buttons, should indicate their state and be distinguishable from non-interactive elements. [Learn more](https://web.dev/interactive-element-affordance/).","score":null,"scoreDisplayMode":"manual"},"logical-tab-order":{"id":"logical-tab-order","title":"The page has a logical tab order","description":"Tabbing through the page follows the visual layout. Users cannot focus elements that are offscreen. [Learn more](https://web.dev/logical-tab-order/).","score":null,"scoreDisplayMode":"manual"},"managed-focus":{"id":"managed-focus","title":"The user's focus is directed to new content added to the page","description":"If new content, such as a dialog, is added to the page, the user's focus is directed to it. [Learn more](https://web.dev/managed-focus/).","score":null,"scoreDisplayMode":"manual"},"offscreen-content-hidden":{"id":"offscreen-content-hidden","title":"Offscreen content is hidden from assistive technology","description":"Offscreen content is hidden with display: none or aria-hidden=true. [Learn more](https://web.dev/offscreen-content-hidden/).","score":null,"scoreDisplayMode":"manual"},"use-landmarks":{"id":"use-landmarks","title":"HTML5 landmark elements are used to improve navigation","description":"Landmark elements (\u003cmain>, \u003cnav>, etc.) are used to improve the keyboard navigation of the page for assistive technology. [Learn more](https://web.dev/use-landmarks/).","score":null,"scoreDisplayMode":"manual"},"visual-order-follows-dom":{"id":"visual-order-follows-dom","title":"Visual order on the page follows DOM order","description":"DOM order matches the visual order, improving navigation for assistive technology. [Learn more](https://web.dev/visual-order-follows-dom/).","score":null,"scoreDisplayMode":"manual"},"uses-long-cache-ttl":{"id":"uses-long-cache-ttl","title":"Uses efficient cache policy on static assets","description":"A long cache lifetime can speed up repeat visits to your page. [Learn more](https://web.dev/uses-long-cache-ttl).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"total-byte-weight":{"id":"total-byte-weight","title":"Avoids enormous network payloads","description":"Large network payloads cost users real money and are highly correlated with long load times. [Learn more](https://web.dev/total-byte-weight).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"offscreen-images":{"id":"offscreen-images","title":"Defer offscreen images","description":"Consider lazy-loading offscreen and hidden images after all critical resources have finished loading to lower time to interactive. [Learn more](https://web.dev/offscreen-images).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ImageElements gatherer did not run."},"render-blocking-resources":{"id":"render-blocking-resources","title":"Eliminate render-blocking resources","description":"Resources are blocking the first paint of your page. Consider delivering critical JS/CSS inline and deferring all non-critical JS/styles. [Learn more](https://web.dev/render-blocking-resources).","score":null,"scoreDisplayMode":"error","errorMessage":"Required TagsBlockingFirstPaint gatherer did not run."},"unminified-css":{"id":"unminified-css","title":"Minify CSS","description":"Minifying CSS files can reduce network payload sizes. [Learn more](https://web.dev/unminified-css).","score":null,"scoreDisplayMode":"error","errorMessage":"Required CSSUsage gatherer did not run."},"unminified-javascript":{"id":"unminified-javascript","title":"Minify JavaScript","description":"Minifying JavaScript files can reduce payload sizes and script parse time. [Learn more](https://web.dev/unminified-javascript).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ScriptElements gatherer did not run."},"unused-css-rules":{"id":"unused-css-rules","title":"Remove unused CSS","description":"Remove dead rules from stylesheets and defer the loading of CSS not used for above-the-fold content to reduce unnecessary bytes consumed by network activity. [Learn more](https://web.dev/unused-css-rules).","score":null,"scoreDisplayMode":"error","errorMessage":"Required CSSUsage gatherer did not run."},"uses-webp-images":{"id":"uses-webp-images","title":"Serve images in next-gen formats","description":"Image formats like JPEG 2000, JPEG XR, and WebP often provide better compression than PNG or JPEG, which means faster downloads and less data consumption. [Learn more](https://web.dev/uses-webp-images).","score":null,"scoreDisplayMode":"error","errorMessage":"Required OptimizedImages gatherer did not run."},"uses-optimized-images":{"id":"uses-optimized-images","title":"Efficiently encode images","description":"Optimized images load faster and consume less cellular data. [Learn more](https://web.dev/uses-optimized-images).","score":null,"scoreDisplayMode":"error","errorMessage":"Required OptimizedImages gatherer did not run."},"uses-text-compression":{"id":"uses-text-compression","title":"Enable text compression","description":"Text-based resources should be served with compression (gzip, deflate or brotli) to minimize total network bytes. [Learn more](https://web.dev/uses-text-compression).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ResponseCompression gatherer did not run."},"uses-responsive-images":{"id":"uses-responsive-images","title":"Properly size images","description":"Serve images that are appropriately-sized to save cellular data and improve load time. [Learn more](https://web.dev/uses-responsive-images).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ImageElements gatherer did not run."},"efficient-animated-content":{"id":"efficient-animated-content","title":"Use video formats for animated content","description":"Large GIFs are inefficient for delivering animated content. Consider using MPEG4/WebM videos for animations and PNG/WebP for static images instead of GIF to save network bytes. [Learn more](https://web.dev/efficient-animated-content)","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"appcache-manifest":{"id":"appcache-manifest","title":"Avoids Application Cache","description":"Application Cache is deprecated. [Learn more](https://web.dev/appcache-manifest).","score":null,"scoreDisplayMode":"error","errorMessage":"Required AppCacheManifest gatherer did not run."},"doctype":{"id":"doctype","title":"Page has the HTML doctype","description":"Specifying a doctype prevents the browser from switching to quirks-mode. [Learn more](https://web.dev/doctype).","score":null,"scoreDisplayMode":"error","errorMessage":"Required Doctype gatherer did not run."},"dom-size":{"id":"dom-size","title":"Avoids an excessive DOM size","description":"A large DOM will increase memory usage, cause longer [style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://web.dev/dom-size).","score":null,"scoreDisplayMode":"error","errorMessage":"Required DOMStats gatherer did not run."},"external-anchors-use-rel-noopener":{"id":"external-anchors-use-rel-noopener","title":"Links to cross-origin destinations are safe","description":"Add `rel=\"noopener\"` or `rel=\"noreferrer\"` to any external links to improve performance and prevent security vulnerabilities. [Learn more](https://web.dev/external-anchors-use-rel-noopener).","score":null,"scoreDisplayMode":"error","errorMessage":"Required AnchorElements gatherer did not run."},"geolocation-on-start":{"id":"geolocation-on-start","title":"Avoids requesting the geolocation permission on page load","description":"Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to a user action instead. [Learn more](https://web.dev/geolocation-on-start).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ConsoleMessages gatherer did not run."},"no-document-write":{"id":"no-document-write","title":"Avoids `document.write()`","description":"For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://web.dev/no-document-write).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ConsoleMessages gatherer did not run."},"no-vulnerable-libraries":{"id":"no-vulnerable-libraries","title":"Avoids front-end JavaScript libraries with known security vulnerabilities","description":"Some third-party scripts may contain known security vulnerabilities that are easily identified and exploited by attackers. [Learn more](https://web.dev/no-vulnerable-libraries).","score":1,"scoreDisplayMode":"binary"},"js-libraries":{"id":"js-libraries","title":"Detected JavaScript libraries","description":"All front-end JavaScript libraries detected on the page. [Learn more](https://web.dev/js-libraries).","score":1,"scoreDisplayMode":"binary","details":{"type":"table","headings":[],"items":[],"summary":{}}},"notification-on-start":{"id":"notification-on-start","title":"Avoids requesting the notification permission on page load","description":"Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://web.dev/notification-on-start).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ConsoleMessages gatherer did not run."},"password-inputs-can-be-pasted-into":{"id":"password-inputs-can-be-pasted-into","title":"Allows users to paste into password fields","description":"Preventing password pasting undermines good security policy. [Learn more](https://web.dev/password-inputs-can-be-pasted-into).","score":null,"scoreDisplayMode":"error","errorMessage":"Required PasswordInputsWithPreventedPaste gatherer did not run."},"uses-http2":{"id":"uses-http2","title":"Uses HTTP/2 for its own resources","description":"HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://web.dev/uses-http2).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"uses-passive-event-listeners":{"id":"uses-passive-event-listeners","title":"Uses passive listeners to improve scrolling performance","description":"Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://web.dev/uses-passive-event-listeners).","score":null,"scoreDisplayMode":"error","errorMessage":"Required ConsoleMessages gatherer did not run."},"meta-description":{"id":"meta-description","title":"Document has a meta description","description":"Meta descriptions may be included in search results to concisely summarize page content. [Learn more](https://web.dev/meta-description).","score":null,"scoreDisplayMode":"error","errorMessage":"Required MetaElements gatherer did not run."},"http-status-code":{"id":"http-status-code","title":"Page has successful HTTP status code","description":"Pages with unsuccessful HTTP status codes may not be indexed properly. [Learn more](https://web.dev/http-status-code).","score":null,"scoreDisplayMode":"error","errorMessage":"Required devtoolsLogs gatherer did not run."},"font-size":{"id":"font-size","title":"Document uses legible font sizes","description":"Font sizes less than 12px are too small to be legible and require mobile visitors to “pinch to zoom” in order to read. Strive to have >60% of page text ≥12px. [Learn more](https://web.dev/font-size).","score":null,"scoreDisplayMode":"error","errorMessage":"Required FontSize gatherer did not run."},"link-text":{"id":"link-text","title":"Links have descriptive text","description":"Descriptive link text helps search engines understand your content. [Learn more](https://web.dev/link-text).","score":null,"scoreDisplayMode":"error","errorMessage":"Required AnchorElements gatherer did not run."},"is-crawlable":{"id":"is-crawlable","title":"Page isn’t blocked from indexing","description":"Search engines are unable to include your pages in search results if they don't have permission to crawl them. [Learn more](https://web.dev/is-crawable).","score":null,"scoreDisplayMode":"error","errorMessage":"Required MetaElements gatherer did not run."},"robots-txt":{"id":"robots-txt","title":"robots.txt is valid","description":"If your robots.txt file is malformed, crawlers may not be able to understand how you want your website to be crawled or indexed. [Learn more](https://web.dev/robots-txt).","score":null,"scoreDisplayMode":"error","errorMessage":"Required RobotsTxt gatherer did not run."},"tap-targets":{"id":"tap-targets","title":"Tap targets are sized appropriately","description":"Interactive elements like buttons and links should be large enough (48x48px), and have enough space around them, to be easy enough to tap without overlapping onto other elements. [Learn more](https://web.dev/tap-targets).","score":null,"scoreDisplayMode":"error","errorMessage":"Required MetaElements gatherer did not run."},"hreflang":{"id":"hreflang","title":"Document has a valid `hreflang`","description":"hreflang links tell search engines what version of a page they should list in search results for a given language or region. [Learn more](https://web.dev/hreflang).","score":null,"scoreDisplayMode":"error","errorMessage":"Required LinkElements gatherer did not run."},"plugins":{"id":"plugins","title":"Document avoids plugins","description":"Search engines can't index plugin content, and many devices restrict plugins or don't support them. [Learn more](https://web.dev/plugins).","score":null,"scoreDisplayMode":"error","errorMessage":"Required EmbeddedContent gatherer did not run."},"canonical":{"id":"canonical","title":"Document has a valid `rel=canonical`","description":"Canonical links suggest which URL to show in search results. [Learn more](https://web.dev/canonical).","score":null,"scoreDisplayMode":"error","errorMessage":"Required LinkElements gatherer did not run."},"structured-data":{"id":"structured-data","title":"Structured data is valid","description":"Run the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/) and the [Structured Data Linter](http://linter.structured-data.org/) to validate structured data. [Learn more](https://web.dev/structured-data).","score":null,"scoreDisplayMode":"manual"}},"configSettings":{"output":"html","maxWaitForFcp":30000,"maxWaitForLoad":45000,"throttlingMethod":"simulate","throttling":{"rttMs":150,"throughputKbps":1638.4,"requestLatencyMs":562.5,"downloadThroughputKbps":1474.5600000000002,"uploadThroughputKbps":675,"cpuSlowdownMultiplier":4},"auditMode":false,"gatherMode":false,"disableStorageReset":false,"emulatedFormFactor":"mobile","channel":"node","budgets":null,"locale":"en-US","blockedUrlPatterns":null,"additionalTraceCategories":null,"extraHeaders":null,"precomputedLanternData":null,"onlyAudits":null,"onlyCategories":null,"skipAudits":null},"categories":{"performance":{"title":"Performance","auditRefs":[{"id":"first-contentful-paint","weight":3,"group":"metrics"},{"id":"first-meaningful-paint","weight":1,"group":"metrics"},{"id":"speed-index","weight":4,"group":"metrics"},{"id":"interactive","weight":5,"group":"metrics"},{"id":"first-cpu-idle","weight":2,"group":"metrics"},{"id":"max-potential-fid","weight":0,"group":"metrics"},{"id":"estimated-input-latency","weight":0},{"id":"total-blocking-time","weight":0},{"id":"render-blocking-resources","weight":0,"group":"load-opportunities"},{"id":"uses-responsive-images","weight":0,"group":"load-opportunities"},{"id":"offscreen-images","weight":0,"group":"load-opportunities"},{"id":"unminified-css","weight":0,"group":"load-opportunities"},{"id":"unminified-javascript","weight":0,"group":"load-opportunities"},{"id":"unused-css-rules","weight":0,"group":"load-opportunities"},{"id":"uses-optimized-images","weight":0,"group":"load-opportunities"},{"id":"uses-webp-images","weight":0,"group":"load-opportunities"},{"id":"uses-text-compression","weight":0,"group":"load-opportunities"},{"id":"uses-rel-preconnect","weight":0,"group":"load-opportunities"},{"id":"time-to-first-byte","weight":0,"group":"load-opportunities"},{"id":"redirects","weight":0,"group":"load-opportunities"},{"id":"uses-rel-preload","weight":0,"group":"load-opportunities"},{"id":"efficient-animated-content","weight":0,"group":"load-opportunities"},{"id":"total-byte-weight","weight":0,"group":"diagnostics"},{"id":"uses-long-cache-ttl","weight":0,"group":"diagnostics"},{"id":"dom-size","weight":0,"group":"diagnostics"},{"id":"critical-request-chains","weight":0,"group":"diagnostics"},{"id":"user-timings","weight":0,"group":"diagnostics"},{"id":"bootup-time","weight":0,"group":"diagnostics"},{"id":"mainthread-work-breakdown","weight":0,"group":"diagnostics"},{"id":"font-display","weight":0,"group":"diagnostics"},{"id":"performance-budget","weight":0,"group":"budgets"},{"id":"resource-summary","weight":0,"group":"diagnostics"},{"id":"third-party-summary","weight":0,"group":"diagnostics"},{"id":"network-requests","weight":0},{"id":"network-rtt","weight":0},{"id":"network-server-latency","weight":0},{"id":"main-thread-tasks","weight":0},{"id":"diagnostics","weight":0},{"id":"metrics","weight":0},{"id":"screenshot-thumbnails","weight":0},{"id":"final-screenshot","weight":0}],"id":"performance","score":null},"accessibility":{"title":"Accessibility","description":"These checks highlight opportunities to [improve the accessibility of your web app](https://developers.google.com/web/fundamentals/accessibility). Only a subset of accessibility issues can be automatically detected so manual testing is also encouraged.","manualDescription":"These items address areas which an automated testing tool cannot cover. Learn more in our guide on [conducting an accessibility review](https://developers.google.com/web/fundamentals/accessibility/how-to-review).","auditRefs":[{"id":"accesskeys","weight":3,"group":"a11y-navigation"},{"id":"aria-allowed-attr","weight":10,"group":"a11y-aria"},{"id":"aria-required-attr","weight":10,"group":"a11y-aria"},{"id":"aria-required-children","weight":10,"group":"a11y-aria"},{"id":"aria-required-parent","weight":10,"group":"a11y-aria"},{"id":"aria-roles","weight":10,"group":"a11y-aria"},{"id":"aria-valid-attr-value","weight":10,"group":"a11y-aria"},{"id":"aria-valid-attr","weight":10,"group":"a11y-aria"},{"id":"audio-caption","weight":10,"group":"a11y-audio-video"},{"id":"button-name","weight":10,"group":"a11y-names-labels"},{"id":"bypass","weight":3,"group":"a11y-navigation"},{"id":"color-contrast","weight":3,"group":"a11y-color-contrast"},{"id":"definition-list","weight":3,"group":"a11y-tables-lists"},{"id":"dlitem","weight":3,"group":"a11y-tables-lists"},{"id":"document-title","weight":3,"group":"a11y-names-labels"},{"id":"duplicate-id","weight":1,"group":"a11y-best-practices"},{"id":"frame-title","weight":3,"group":"a11y-names-labels"},{"id":"html-has-lang","weight":3,"group":"a11y-language"},{"id":"html-lang-valid","weight":3,"group":"a11y-language"},{"id":"image-alt","weight":10,"group":"a11y-names-labels"},{"id":"input-image-alt","weight":10,"group":"a11y-names-labels"},{"id":"label","weight":10,"group":"a11y-names-labels"},{"id":"layout-table","weight":3,"group":"a11y-tables-lists"},{"id":"link-name","weight":3,"group":"a11y-names-labels"},{"id":"list","weight":3,"group":"a11y-tables-lists"},{"id":"listitem","weight":3,"group":"a11y-tables-lists"},{"id":"meta-refresh","weight":10,"group":"a11y-best-practices"},{"id":"meta-viewport","weight":10,"group":"a11y-best-practices"},{"id":"object-alt","weight":3,"group":"a11y-names-labels"},{"id":"tabindex","weight":3,"group":"a11y-navigation"},{"id":"td-headers-attr","weight":3,"group":"a11y-tables-lists"},{"id":"th-has-data-cells","weight":3,"group":"a11y-tables-lists"},{"id":"valid-lang","weight":3,"group":"a11y-language"},{"id":"video-caption","weight":10,"group":"a11y-audio-video"},{"id":"video-description","weight":10,"group":"a11y-audio-video"},{"id":"logical-tab-order","weight":0},{"id":"focusable-controls","weight":0},{"id":"interactive-element-affordance","weight":0},{"id":"managed-focus","weight":0},{"id":"focus-traps","weight":0},{"id":"custom-controls-labels","weight":0},{"id":"custom-controls-roles","weight":0},{"id":"visual-order-follows-dom","weight":0},{"id":"offscreen-content-hidden","weight":0},{"id":"heading-levels","weight":0},{"id":"use-landmarks","weight":0}],"id":"accessibility","score":null},"best-practices":{"title":"Best Practices","auditRefs":[{"id":"appcache-manifest","weight":1},{"id":"is-on-https","weight":1},{"id":"uses-http2","weight":1},{"id":"uses-passive-event-listeners","weight":1},{"id":"no-document-write","weight":1},{"id":"external-anchors-use-rel-noopener","weight":1},{"id":"geolocation-on-start","weight":1},{"id":"doctype","weight":1},{"id":"no-vulnerable-libraries","weight":1},{"id":"js-libraries","weight":0},{"id":"notification-on-start","weight":1},{"id":"deprecations","weight":1},{"id":"password-inputs-can-be-pasted-into","weight":1},{"id":"errors-in-console","weight":1},{"id":"image-aspect-ratio","weight":1}],"id":"best-practices","score":null},"seo":{"title":"SEO","description":"These checks ensure that your page is optimized for search engine results ranking. There are additional factors Lighthouse does not check that may affect your search ranking. [Learn more](https://support.google.com/webmasters/answer/35769).","manualDescription":"Run these additional validators on your site to check additional SEO best practices.","auditRefs":[{"id":"viewport","weight":1,"group":"seo-mobile"},{"id":"document-title","weight":1,"group":"seo-content"},{"id":"meta-description","weight":1,"group":"seo-content"},{"id":"http-status-code","weight":1,"group":"seo-crawl"},{"id":"link-text","weight":1,"group":"seo-content"},{"id":"is-crawlable","weight":1,"group":"seo-crawl"},{"id":"robots-txt","weight":1,"group":"seo-crawl"},{"id":"image-alt","weight":1,"group":"seo-content"},{"id":"hreflang","weight":1,"group":"seo-content"},{"id":"canonical","weight":1,"group":"seo-content"},{"id":"font-size","weight":1,"group":"seo-mobile"},{"id":"plugins","weight":1,"group":"seo-content"},{"id":"tap-targets","weight":1,"group":"seo-mobile"},{"id":"structured-data","weight":0}],"id":"seo","score":null},"pwa":{"title":"Progressive Web App","description":"These checks validate the aspects of a Progressive Web App. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist).","manualDescription":"These checks are required by the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist) but are not automatically checked by Lighthouse. They do not affect your score but it's important that you verify them manually.","auditRefs":[{"id":"load-fast-enough-for-pwa","weight":7,"group":"pwa-fast-reliable"},{"id":"works-offline","weight":5,"group":"pwa-fast-reliable"},{"id":"offline-start-url","weight":1,"group":"pwa-fast-reliable"},{"id":"is-on-https","weight":2,"group":"pwa-installable"},{"id":"service-worker","weight":1,"group":"pwa-installable"},{"id":"installable-manifest","weight":2,"group":"pwa-installable"},{"id":"redirects-http","weight":2,"group":"pwa-optimized"},{"id":"splash-screen","weight":1,"group":"pwa-optimized"},{"id":"themed-omnibox","weight":1,"group":"pwa-optimized"},{"id":"content-width","weight":1,"group":"pwa-optimized"},{"id":"viewport","weight":2,"group":"pwa-optimized"},{"id":"without-javascript","weight":1,"group":"pwa-optimized"},{"id":"apple-touch-icon","weight":1,"group":"pwa-optimized"},{"id":"pwa-cross-browser","weight":0},{"id":"pwa-page-transitions","weight":0},{"id":"pwa-each-page-has-url","weight":0}],"id":"pwa","score":null}},"categoryGroups":{"metrics":{"title":"Metrics"},"load-opportunities":{"title":"Opportunities","description":"These suggestions can help your page load faster. They don't [directly affect](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) the Performance score."},"budgets":{"title":"Budgets","description":"Performance budgets set standards for the performance of your site."},"diagnostics":{"title":"Diagnostics","description":"More information about the performance of your application. These numbers don't [directly affect](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) the Performance score."},"pwa-fast-reliable":{"title":"Fast and reliable"},"pwa-installable":{"title":"Installable"},"pwa-optimized":{"title":"PWA Optimized"},"a11y-best-practices":{"title":"Best practices","description":"These items highlight common accessibility best practices."},"a11y-color-contrast":{"title":"Contrast","description":"These are opportunities to improve the legibility of your content."},"a11y-names-labels":{"title":"Names and labels","description":"These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."},"a11y-navigation":{"title":"Navigation","description":"These are opportunities to improve keyboard navigation in your application."},"a11y-aria":{"title":"ARIA","description":"These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."},"a11y-language":{"title":"Internationalization and localization","description":"These are opportunities to improve the interpretation of your content by users in different locales."},"a11y-audio-video":{"title":"Audio and video","description":"These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."},"a11y-tables-lists":{"title":"Tables and lists","description":"These are opportunities to to improve the experience of reading tabular or list data using assistive technology, like a screen reader."},"seo-mobile":{"title":"Mobile Friendly","description":"Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn more](https://developers.google.com/search/mobile-sites/)."},"seo-content":{"title":"Content Best Practices","description":"Format your HTML in a way that enables crawlers to better understand your app’s content."},"seo-crawl":{"title":"Crawling and Indexing","description":"To appear in search results, crawlers need access to your app."}},"timing":{"entries":[{"startTime":4716.42,"name":"lh:init:config","duration":2381.99,"entryType":"measure"},{"startTime":4720.63,"name":"lh:config:requireGatherers","duration":413.59,"entryType":"measure"},{"startTime":5134.71,"name":"lh:config:requireAudits","duration":1933.3,"entryType":"measure"},{"startTime":7099.87,"name":"lh:runner:run","duration":31547.62,"entryType":"measure"},{"startTime":7105.71,"name":"lh:init:connect","duration":235.6,"entryType":"measure"},{"startTime":7341.94,"name":"lh:gather:loadBlank","duration":53.93,"entryType":"measure"},{"startTime":7396.17,"name":"lh:gather:getVersion","duration":5.09,"entryType":"measure"},{"startTime":7404.76,"name":"lh:gather:getBenchmarkIndex","duration":515.94,"entryType":"measure"},{"startTime":7920.9,"name":"lh:gather:setupDriver","duration":76.27,"entryType":"measure"},{"startTime":7997.72,"name":"lh:gather:loadBlank","duration":75.29,"entryType":"measure"},{"startTime":8073.3,"name":"lh:gather:setupPassNetwork","duration":10.41,"entryType":"measure"},{"startTime":8083.99,"name":"lh:driver:cleanBrowserCaches","duration":23.98,"entryType":"measure"},{"startTime":8108.33,"name":"lh:gather:beforePass","duration":10.74,"entryType":"measure"},{"startTime":8108.41,"name":"lh:gather:beforePass:CSSUsage","duration":0.4,"entryType":"measure"},{"startTime":8108.99,"name":"lh:gather:beforePass:ViewportDimensions","duration":0.09,"entryType":"measure"},{"startTime":8109.12,"name":"lh:gather:beforePass:RuntimeExceptions","duration":0.24,"entryType":"measure"},{"startTime":8109.56,"name":"lh:gather:beforePass:ConsoleMessages","duration":5.45,"entryType":"measure"},{"startTime":8115.08,"name":"lh:gather:beforePass:AnchorElements","duration":0.05,"entryType":"measure"},{"startTime":8115.17,"name":"lh:gather:beforePass:ImageElements","duration":0.04,"entryType":"measure"},{"startTime":8115.23,"name":"lh:gather:beforePass:LinkElements","duration":0.04,"entryType":"measure"},{"startTime":8115.3,"name":"lh:gather:beforePass:MetaElements","duration":0.04,"entryType":"measure"},{"startTime":8115.38,"name":"lh:gather:beforePass:ScriptElements","duration":0.03,"entryType":"measure"},{"startTime":8115.58,"name":"lh:gather:beforePass:IFrameElements","duration":0.07,"entryType":"measure"},{"startTime":8115.71,"name":"lh:gather:beforePass:MainDocumentContent","duration":0.04,"entryType":"measure"},{"startTime":8115.77,"name":"lh:gather:beforePass:AppCacheManifest","duration":0.03,"entryType":"measure"},{"startTime":8115.83,"name":"lh:gather:beforePass:Doctype","duration":0.03,"entryType":"measure"},{"startTime":8115.89,"name":"lh:gather:beforePass:DOMStats","duration":0.03,"entryType":"measure"},{"startTime":8115.95,"name":"lh:gather:beforePass:OptimizedImages","duration":0.03,"entryType":"measure"},{"startTime":8116.01,"name":"lh:gather:beforePass:PasswordInputsWithPreventedPaste","duration":0.03,"entryType":"measure"},{"startTime":8116.06,"name":"lh:gather:beforePass:ResponseCompression","duration":0.03,"entryType":"measure"},{"startTime":8116.11,"name":"lh:gather:beforePass:TagsBlockingFirstPaint","duration":2.45,"entryType":"measure"},{"startTime":8118.74,"name":"lh:gather:beforePass:FontSize","duration":0.06,"entryType":"measure"},{"startTime":8118.83,"name":"lh:gather:beforePass:EmbeddedContent","duration":0.06,"entryType":"measure"},{"startTime":8118.92,"name":"lh:gather:beforePass:RobotsTxt","duration":0.03,"entryType":"measure"},{"startTime":8118.97,"name":"lh:gather:beforePass:TapTargets","duration":0.03,"entryType":"measure"},{"startTime":8119.02,"name":"lh:gather:beforePass:Accessibility","duration":0.03,"entryType":"measure"},{"startTime":8119.26,"name":"lh:gather:beginRecording","duration":21.05,"entryType":"measure"},{"startTime":8123.62,"name":"lh:gather:getVersion","duration":2.57,"entryType":"measure"},{"startTime":8141.6,"name":"lh:gather:loadPage-defaultPass","duration":30027.94,"entryType":"measure"},{"startTime":38169.9,"name":"lh:gather:pass","duration":6.3,"entryType":"measure"},{"startTime":38176.74,"name":"lh:gather:getTrace","duration":61.67,"entryType":"measure"},{"startTime":38238.44,"name":"lh:gather:getDevtoolsLog","duration":1.74,"entryType":"measure"},{"startTime":38260.33,"name":"lh:gather:disconnect","duration":18.44,"entryType":"measure"},{"startTime":38279.44,"name":"lh:runner:auditing","duration":356.75,"entryType":"measure"},{"startTime":38298.8,"name":"lh:audit:is-on-https","duration":5.32,"entryType":"measure"},{"startTime":38304.71,"name":"lh:audit:redirects-http","duration":1.05,"entryType":"measure"},{"startTime":38306.68,"name":"lh:audit:service-worker","duration":3.01,"entryType":"measure"},{"startTime":38310.71,"name":"lh:audit:works-offline","duration":3.36,"entryType":"measure"},{"startTime":38314.65,"name":"lh:audit:viewport","duration":2.82,"entryType":"measure"},{"startTime":38318.45,"name":"lh:audit:without-javascript","duration":3.48,"entryType":"measure"},{"startTime":38322.37,"name":"lh:audit:first-contentful-paint","duration":1.81,"entryType":"measure"},{"startTime":38324.92,"name":"lh:audit:first-meaningful-paint","duration":0.91,"entryType":"measure"},{"startTime":38326.79,"name":"lh:audit:load-fast-enough-for-pwa","duration":1.08,"entryType":"measure"},{"startTime":38329.13,"name":"lh:audit:speed-index","duration":1.41,"entryType":"measure"},{"startTime":38330.64,"name":"lh:audit:screenshot-thumbnails","duration":0.91,"entryType":"measure"},{"startTime":38331.6,"name":"lh:audit:final-screenshot","duration":0.55,"entryType":"measure"},{"startTime":38333,"name":"lh:audit:estimated-input-latency","duration":1.1,"entryType":"measure"},{"startTime":38334.72,"name":"lh:audit:total-blocking-time","duration":0.93,"entryType":"measure"},{"startTime":38336.46,"name":"lh:audit:max-potential-fid","duration":1.25,"entryType":"measure"},{"startTime":38338.38,"name":"lh:audit:errors-in-console","duration":1.45,"entryType":"measure"},{"startTime":38340.5,"name":"lh:audit:time-to-first-byte","duration":1.01,"entryType":"measure"},{"startTime":38342.05,"name":"lh:audit:first-cpu-idle","duration":2.34,"entryType":"measure"},{"startTime":38344.83,"name":"lh:audit:interactive","duration":1.32,"entryType":"measure"},{"startTime":38346.68,"name":"lh:audit:user-timings","duration":0.66,"entryType":"measure"},{"startTime":38351.69,"name":"lh:audit:critical-request-chains","duration":0.94,"entryType":"measure"},{"startTime":38354.17,"name":"lh:audit:redirects","duration":1.58,"entryType":"measure"},{"startTime":38356.23,"name":"lh:audit:installable-manifest","duration":5.31,"entryType":"measure"},{"startTime":38359.81,"name":"lh:computed:ManifestValues","duration":0.49,"entryType":"measure"},{"startTime":38361.99,"name":"lh:audit:apple-touch-icon","duration":4.96,"entryType":"measure"},{"startTime":38367.61,"name":"lh:audit:splash-screen","duration":1.11,"entryType":"measure"},{"startTime":38369.65,"name":"lh:audit:themed-omnibox","duration":1.77,"entryType":"measure"},{"startTime":38372.54,"name":"lh:audit:content-width","duration":1.15,"entryType":"measure"},{"startTime":38375.22,"name":"lh:audit:image-aspect-ratio","duration":3.29,"entryType":"measure"},{"startTime":38379.19,"name":"lh:audit:deprecations","duration":1.49,"entryType":"measure"},{"startTime":38381.47,"name":"lh:audit:mainthread-work-breakdown","duration":1.05,"entryType":"measure"},{"startTime":38383.19,"name":"lh:audit:bootup-time","duration":1.36,"entryType":"measure"},{"startTime":38384.96,"name":"lh:audit:uses-rel-preload","duration":0.79,"entryType":"measure"},{"startTime":38386.44,"name":"lh:audit:uses-rel-preconnect","duration":1.14,"entryType":"measure"},{"startTime":38388.74,"name":"lh:audit:font-display","duration":0.88,"entryType":"measure"},{"startTime":38389.68,"name":"lh:audit:diagnostics","duration":1.48,"entryType":"measure"},{"startTime":38391.47,"name":"lh:audit:network-requests","duration":0.51,"entryType":"measure"},{"startTime":38392.31,"name":"lh:audit:network-rtt","duration":0.75,"entryType":"measure"},{"startTime":38393.48,"name":"lh:audit:network-server-latency","duration":1.68,"entryType":"measure"},{"startTime":38395.22,"name":"lh:audit:main-thread-tasks","duration":0.77,"entryType":"measure"},{"startTime":38396.04,"name":"lh:audit:metrics","duration":0.87,"entryType":"measure"},{"startTime":38397.86,"name":"lh:audit:offline-start-url","duration":1.92,"entryType":"measure"},{"startTime":38400.1,"name":"lh:audit:performance-budget","duration":2.46,"entryType":"measure"},{"startTime":38402.99,"name":"lh:audit:resource-summary","duration":0.84,"entryType":"measure"},{"startTime":38404.26,"name":"lh:audit:third-party-summary","duration":5.46,"entryType":"measure"},{"startTime":38410.13,"name":"lh:audit:pwa-cross-browser","duration":0.68,"entryType":"measure"},{"startTime":38411.58,"name":"lh:audit:pwa-page-transitions","duration":0.3,"entryType":"measure"},{"startTime":38412.09,"name":"lh:audit:pwa-each-page-has-url","duration":0.57,"entryType":"measure"},{"startTime":38413.24,"name":"lh:audit:accesskeys","duration":1.55,"entryType":"measure"},{"startTime":38415.19,"name":"lh:audit:aria-allowed-attr","duration":4.26,"entryType":"measure"},{"startTime":38419.86,"name":"lh:audit:aria-required-attr","duration":1.69,"entryType":"measure"},{"startTime":38422.19,"name":"lh:audit:aria-required-children","duration":1.14,"entryType":"measure"},{"startTime":38426.24,"name":"lh:audit:aria-required-parent","duration":1.58,"entryType":"measure"},{"startTime":38428.69,"name":"lh:audit:aria-roles","duration":2.05,"entryType":"measure"},{"startTime":38431.14,"name":"lh:audit:aria-valid-attr-value","duration":1.27,"entryType":"measure"},{"startTime":38433.15,"name":"lh:audit:aria-valid-attr","duration":1.95,"entryType":"measure"},{"startTime":38435.7,"name":"lh:audit:audio-caption","duration":1.87,"entryType":"measure"},{"startTime":38437.92,"name":"lh:audit:button-name","duration":1.96,"entryType":"measure"},{"startTime":38440.35,"name":"lh:audit:bypass","duration":1.34,"entryType":"measure"},{"startTime":38442.53,"name":"lh:audit:color-contrast","duration":1.35,"entryType":"measure"},{"startTime":38446.02,"name":"lh:audit:definition-list","duration":1.51,"entryType":"measure"},{"startTime":38448.01,"name":"lh:audit:dlitem","duration":1.18,"entryType":"measure"},{"startTime":38450,"name":"lh:audit:document-title","duration":1.07,"entryType":"measure"},{"startTime":38451.59,"name":"lh:audit:duplicate-id","duration":1.27,"entryType":"measure"},{"startTime":38453.71,"name":"lh:audit:frame-title","duration":1.28,"entryType":"measure"},{"startTime":38456.18,"name":"lh:audit:html-has-lang","duration":1.06,"entryType":"measure"},{"startTime":38457.95,"name":"lh:audit:html-lang-valid","duration":1.5,"entryType":"measure"},{"startTime":38459.84,"name":"lh:audit:image-alt","duration":1.15,"entryType":"measure"},{"startTime":38462.58,"name":"lh:audit:input-image-alt","duration":4.79,"entryType":"measure"},{"startTime":38467.95,"name":"lh:audit:label","duration":1.63,"entryType":"measure"},{"startTime":38470.24,"name":"lh:audit:layout-table","duration":2.92,"entryType":"measure"},{"startTime":38475.53,"name":"lh:audit:link-name","duration":2.79,"entryType":"measure"},{"startTime":38479.2,"name":"lh:audit:list","duration":3.36,"entryType":"measure"},{"startTime":38483.19,"name":"lh:audit:listitem","duration":2.68,"entryType":"measure"},{"startTime":38486.38,"name":"lh:audit:meta-refresh","duration":3.54,"entryType":"measure"},{"startTime":38491.06,"name":"lh:audit:meta-viewport","duration":4.24,"entryType":"measure"},{"startTime":38495.92,"name":"lh:audit:object-alt","duration":4.45,"entryType":"measure"},{"startTime":38500.89,"name":"lh:audit:tabindex","duration":2.06,"entryType":"measure"},{"startTime":38503.92,"name":"lh:audit:td-headers-attr","duration":3.09,"entryType":"measure"},{"startTime":38508.03,"name":"lh:audit:th-has-data-cells","duration":2.53,"entryType":"measure"},{"startTime":38510.98,"name":"lh:audit:valid-lang","duration":1.09,"entryType":"measure"},{"startTime":38512.96,"name":"lh:audit:video-caption","duration":1.47,"entryType":"measure"},{"startTime":38515,"name":"lh:audit:video-description","duration":1.45,"entryType":"measure"},{"startTime":38516.56,"name":"lh:audit:custom-controls-labels","duration":0.23,"entryType":"measure"},{"startTime":38516.85,"name":"lh:audit:custom-controls-roles","duration":0.37,"entryType":"measure"},{"startTime":38517.38,"name":"lh:audit:focus-traps","duration":0.27,"entryType":"measure"},{"startTime":38517.75,"name":"lh:audit:focusable-controls","duration":0.2,"entryType":"measure"},{"startTime":38519.38,"name":"lh:audit:heading-levels","duration":0.24,"entryType":"measure"},{"startTime":38519.66,"name":"lh:audit:interactive-element-affordance","duration":0.14,"entryType":"measure"},{"startTime":38519.84,"name":"lh:audit:logical-tab-order","duration":0.14,"entryType":"measure"},{"startTime":38520.01,"name":"lh:audit:managed-focus","duration":0.13,"entryType":"measure"},{"startTime":38520.19,"name":"lh:audit:offscreen-content-hidden","duration":0.13,"entryType":"measure"},{"startTime":38520.35,"name":"lh:audit:use-landmarks","duration":2.42,"entryType":"measure"},{"startTime":38522.82,"name":"lh:audit:visual-order-follows-dom","duration":1.38,"entryType":"measure"},{"startTime":38525.21,"name":"lh:audit:uses-long-cache-ttl","duration":1.31,"entryType":"measure"},{"startTime":38534.41,"name":"lh:audit:total-byte-weight","duration":0.75,"entryType":"measure"},{"startTime":38535.69,"name":"lh:audit:offscreen-images","duration":0.9,"entryType":"measure"},{"startTime":38537.03,"name":"lh:audit:render-blocking-resources","duration":0.87,"entryType":"measure"},{"startTime":38538.21,"name":"lh:audit:unminified-css","duration":5.09,"entryType":"measure"},{"startTime":38543.75,"name":"lh:audit:unminified-javascript","duration":2.98,"entryType":"measure"},{"startTime":38547.07,"name":"lh:audit:unused-css-rules","duration":5.23,"entryType":"measure"},{"startTime":38552.92,"name":"lh:audit:uses-webp-images","duration":3.32,"entryType":"measure"},{"startTime":38556.96,"name":"lh:audit:uses-optimized-images","duration":2.44,"entryType":"measure"},{"startTime":38559.73,"name":"lh:audit:uses-text-compression","duration":1.66,"entryType":"measure"},{"startTime":38563.24,"name":"lh:audit:uses-responsive-images","duration":3.36,"entryType":"measure"},{"startTime":38566.9,"name":"lh:audit:efficient-animated-content","duration":2.66,"entryType":"measure"},{"startTime":38569.92,"name":"lh:audit:appcache-manifest","duration":2.55,"entryType":"measure"},{"startTime":38572.88,"name":"lh:audit:doctype","duration":2.9,"entryType":"measure"},{"startTime":38576.18,"name":"lh:audit:dom-size","duration":3.58,"entryType":"measure"},{"startTime":38580.19,"name":"lh:audit:external-anchors-use-rel-noopener","duration":3.95,"entryType":"measure"},{"startTime":38584.74,"name":"lh:audit:geolocation-on-start","duration":1.91,"entryType":"measure"},{"startTime":38587.03,"name":"lh:audit:no-document-write","duration":4.23,"entryType":"measure"},{"startTime":38592.53,"name":"lh:audit:no-vulnerable-libraries","duration":3.51,"entryType":"measure"},{"startTime":38596.55,"name":"lh:audit:js-libraries","duration":1.73,"entryType":"measure"},{"startTime":38598.87,"name":"lh:audit:notification-on-start","duration":3.62,"entryType":"measure"},{"startTime":38602.98,"name":"lh:audit:password-inputs-can-be-pasted-into","duration":6.31,"entryType":"measure"},{"startTime":38609.73,"name":"lh:audit:uses-http2","duration":2.14,"entryType":"measure"},{"startTime":38612.21,"name":"lh:audit:uses-passive-event-listeners","duration":1.37,"entryType":"measure"},{"startTime":38614.8,"name":"lh:audit:meta-description","duration":1.91,"entryType":"measure"},{"startTime":38617.34,"name":"lh:audit:http-status-code","duration":1.13,"entryType":"measure"},{"startTime":38619.85,"name":"lh:audit:font-size","duration":1.37,"entryType":"measure"},{"startTime":38621.75,"name":"lh:audit:link-text","duration":5.72,"entryType":"measure"},{"startTime":38628.01,"name":"lh:audit:is-crawlable","duration":0.98,"entryType":"measure"},{"startTime":38629.95,"name":"lh:audit:robots-txt","duration":1.28,"entryType":"measure"},{"startTime":38632.18,"name":"lh:audit:tap-targets","duration":0.77,"entryType":"measure"},{"startTime":38633.18,"name":"lh:audit:hreflang","duration":0.53,"entryType":"measure"},{"startTime":38633.89,"name":"lh:audit:plugins","duration":0.69,"entryType":"measure"},{"startTime":38634.81,"name":"lh:audit:canonical","duration":0.56,"entryType":"measure"},{"startTime":38635.73,"name":"lh:audit:structured-data","duration":0.43,"entryType":"measure"},{"startTime":38636.66,"name":"lh:runner:generate","duration":10.8,"entryType":"measure"}],"total":31547.62},"i18n":{"rendererFormattedStrings":{"auditGroupExpandTooltip":"Show audits","crcInitialNavigation":"Initial Navigation","crcLongestDurationLabel":"Maximum critical path latency:","errorLabel":"Error!","errorMissingAuditInfo":"Report error: no audit information","labDataTitle":"Lab Data","lsPerformanceCategoryDescription":"[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.","manualAuditsGroupTitle":"Additional items to manually check","notApplicableAuditsGroupTitle":"Not applicable","opportunityResourceColumnLabel":"Opportunity","opportunitySavingsColumnLabel":"Estimated Savings","passedAuditsGroupTitle":"Passed audits","snippetCollapseButtonLabel":"Collapse snippet","snippetExpandButtonLabel":"Expand snippet","thirdPartyResourcesLabel":"Show 3rd-party resources","toplevelWarningsMessage":"There were issues affecting this run of Lighthouse:","varianceDisclaimer":"Values are estimated and may vary. The performance score is [based only on these metrics](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted).","warningAuditsGroupTitle":"Passed audits but with warnings","warningHeader":"Warnings: "},"icuMessagePaths":{"lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails":[{"values":{"errorCode":"FAILED_DOCUMENT_REQUEST","errorDetails":"net::ERR_CERT_AUTHORITY_INVALID"},"path":"runWarnings[0]"},{"values":{"errorCode":"FAILED_DOCUMENT_REQUEST","errorDetails":"net::ERR_CERT_AUTHORITY_INVALID"},"path":"runtimeError.message"}],"lighthouse-core/audits/is-on-https.js | title":["audits[is-on-https].title"],"lighthouse-core/audits/is-on-https.js | description":["audits[is-on-https].description"],"lighthouse-core/lib/lh-error.js | missingRequiredArtifact":[{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[is-on-https].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"HTTPRedirect"},"path":"audits[redirects-http].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ServiceWorker"},"path":"audits[service-worker].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Offline"},"path":"audits[works-offline].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"MetaElements"},"path":"audits.viewport.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"HTMLWithoutJavaScript"},"path":"audits[without-javascript].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[first-contentful-paint].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[first-meaningful-paint].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[load-fast-enough-for-pwa].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[speed-index].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[screenshot-thumbnails].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[final-screenshot].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[estimated-input-latency].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[total-blocking-time].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[max-potential-fid].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ConsoleMessages"},"path":"audits[errors-in-console].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[time-to-first-byte].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[first-cpu-idle].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits.interactive.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[user-timings].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[critical-request-chains].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits.redirects.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"LinkElements"},"path":"audits[apple-touch-icon].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"MetaElements"},"path":"audits[themed-omnibox].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ViewportDimensions"},"path":"audits[content-width].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ImageElements"},"path":"audits[image-aspect-ratio].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ConsoleMessages"},"path":"audits.deprecations.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[mainthread-work-breakdown].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[bootup-time].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[uses-rel-preload].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[uses-rel-preconnect].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[font-display].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits.diagnostics.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[network-requests].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[network-rtt].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[network-server-latency].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[main-thread-tasks].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits.metrics.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"StartUrl"},"path":"audits[offline-start-url].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[performance-budget].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[resource-summary].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"traces"},"path":"audits[third-party-summary].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits.accesskeys.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[aria-allowed-attr].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[aria-required-attr].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[aria-required-children].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[aria-required-parent].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[aria-roles].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[aria-valid-attr-value].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[aria-valid-attr].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[audio-caption].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[button-name].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits.bypass.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[color-contrast].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[definition-list].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits.dlitem.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[document-title].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[duplicate-id].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[frame-title].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[html-has-lang].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[html-lang-valid].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[image-alt].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[input-image-alt].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits.label.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[layout-table].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[link-name].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits.list.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits.listitem.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[meta-refresh].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[meta-viewport].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[object-alt].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits.tabindex.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[td-headers-attr].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[th-has-data-cells].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[valid-lang].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[video-caption].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Accessibility"},"path":"audits[video-description].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[uses-long-cache-ttl].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[total-byte-weight].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ImageElements"},"path":"audits[offscreen-images].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"TagsBlockingFirstPaint"},"path":"audits[render-blocking-resources].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"CSSUsage"},"path":"audits[unminified-css].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ScriptElements"},"path":"audits[unminified-javascript].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"CSSUsage"},"path":"audits[unused-css-rules].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"OptimizedImages"},"path":"audits[uses-webp-images].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"OptimizedImages"},"path":"audits[uses-optimized-images].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ResponseCompression"},"path":"audits[uses-text-compression].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ImageElements"},"path":"audits[uses-responsive-images].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[efficient-animated-content].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"AppCacheManifest"},"path":"audits[appcache-manifest].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"Doctype"},"path":"audits.doctype.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"DOMStats"},"path":"audits[dom-size].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"AnchorElements"},"path":"audits[external-anchors-use-rel-noopener].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ConsoleMessages"},"path":"audits[geolocation-on-start].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ConsoleMessages"},"path":"audits[no-document-write].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ConsoleMessages"},"path":"audits[notification-on-start].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"PasswordInputsWithPreventedPaste"},"path":"audits[password-inputs-can-be-pasted-into].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[uses-http2].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"ConsoleMessages"},"path":"audits[uses-passive-event-listeners].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"MetaElements"},"path":"audits[meta-description].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"devtoolsLogs"},"path":"audits[http-status-code].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"FontSize"},"path":"audits[font-size].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"AnchorElements"},"path":"audits[link-text].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"MetaElements"},"path":"audits[is-crawlable].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"RobotsTxt"},"path":"audits[robots-txt].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"MetaElements"},"path":"audits[tap-targets].errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"LinkElements"},"path":"audits.hreflang.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"EmbeddedContent"},"path":"audits.plugins.errorMessage"},{"values":{"errorCode":"MISSING_REQUIRED_ARTIFACT","artifactName":"LinkElements"},"path":"audits.canonical.errorMessage"}],"lighthouse-core/audits/redirects-http.js | title":["audits[redirects-http].title"],"lighthouse-core/audits/redirects-http.js | description":["audits[redirects-http].description"],"lighthouse-core/audits/service-worker.js | title":["audits[service-worker].title"],"lighthouse-core/audits/service-worker.js | description":["audits[service-worker].description"],"lighthouse-core/audits/works-offline.js | title":["audits[works-offline].title"],"lighthouse-core/audits/works-offline.js | description":["audits[works-offline].description"],"lighthouse-core/audits/viewport.js | title":["audits.viewport.title"],"lighthouse-core/audits/viewport.js | description":["audits.viewport.description"],"lighthouse-core/audits/without-javascript.js | title":["audits[without-javascript].title"],"lighthouse-core/audits/without-javascript.js | description":["audits[without-javascript].description"],"lighthouse-core/audits/metrics/first-contentful-paint.js | title":["audits[first-contentful-paint].title"],"lighthouse-core/audits/metrics/first-contentful-paint.js | description":["audits[first-contentful-paint].description"],"lighthouse-core/audits/metrics/first-meaningful-paint.js | title":["audits[first-meaningful-paint].title"],"lighthouse-core/audits/metrics/first-meaningful-paint.js | description":["audits[first-meaningful-paint].description"],"lighthouse-core/audits/load-fast-enough-for-pwa.js | title":["audits[load-fast-enough-for-pwa].title"],"lighthouse-core/audits/load-fast-enough-for-pwa.js | description":["audits[load-fast-enough-for-pwa].description"],"lighthouse-core/audits/metrics/speed-index.js | title":["audits[speed-index].title"],"lighthouse-core/audits/metrics/speed-index.js | description":["audits[speed-index].description"],"lighthouse-core/audits/metrics/estimated-input-latency.js | title":["audits[estimated-input-latency].title"],"lighthouse-core/audits/metrics/estimated-input-latency.js | description":["audits[estimated-input-latency].description"],"lighthouse-core/audits/metrics/total-blocking-time.js | title":["audits[total-blocking-time].title"],"lighthouse-core/audits/metrics/total-blocking-time.js | description":["audits[total-blocking-time].description"],"lighthouse-core/audits/metrics/max-potential-fid.js | title":["audits[max-potential-fid].title"],"lighthouse-core/audits/metrics/max-potential-fid.js | description":["audits[max-potential-fid].description"],"lighthouse-core/audits/errors-in-console.js | title":["audits[errors-in-console].title"],"lighthouse-core/audits/errors-in-console.js | description":["audits[errors-in-console].description"],"lighthouse-core/audits/time-to-first-byte.js | title":["audits[time-to-first-byte].title"],"lighthouse-core/audits/time-to-first-byte.js | description":["audits[time-to-first-byte].description"],"lighthouse-core/audits/metrics/first-cpu-idle.js | title":["audits[first-cpu-idle].title"],"lighthouse-core/audits/metrics/first-cpu-idle.js | description":["audits[first-cpu-idle].description"],"lighthouse-core/audits/metrics/interactive.js | title":["audits.interactive.title"],"lighthouse-core/audits/metrics/interactive.js | description":["audits.interactive.description"],"lighthouse-core/audits/user-timings.js | title":["audits[user-timings].title"],"lighthouse-core/audits/user-timings.js | description":["audits[user-timings].description"],"lighthouse-core/audits/critical-request-chains.js | title":["audits[critical-request-chains].title"],"lighthouse-core/audits/critical-request-chains.js | description":["audits[critical-request-chains].description"],"lighthouse-core/audits/redirects.js | title":["audits.redirects.title"],"lighthouse-core/audits/redirects.js | description":["audits.redirects.description"],"lighthouse-core/audits/installable-manifest.js | failureTitle":["audits[installable-manifest].title"],"lighthouse-core/audits/installable-manifest.js | description":["audits[installable-manifest].description"],"lighthouse-core/audits/apple-touch-icon.js | title":["audits[apple-touch-icon].title"],"lighthouse-core/audits/apple-touch-icon.js | description":["audits[apple-touch-icon].description"],"lighthouse-core/audits/splash-screen.js | failureTitle":["audits[splash-screen].title"],"lighthouse-core/audits/splash-screen.js | description":["audits[splash-screen].description"],"lighthouse-core/audits/themed-omnibox.js | title":["audits[themed-omnibox].title"],"lighthouse-core/audits/themed-omnibox.js | description":["audits[themed-omnibox].description"],"lighthouse-core/audits/content-width.js | title":["audits[content-width].title"],"lighthouse-core/audits/content-width.js | description":["audits[content-width].description"],"lighthouse-core/audits/image-aspect-ratio.js | title":["audits[image-aspect-ratio].title"],"lighthouse-core/audits/image-aspect-ratio.js | description":["audits[image-aspect-ratio].description"],"lighthouse-core/audits/deprecations.js | title":["audits.deprecations.title"],"lighthouse-core/audits/deprecations.js | description":["audits.deprecations.description"],"lighthouse-core/audits/mainthread-work-breakdown.js | title":["audits[mainthread-work-breakdown].title"],"lighthouse-core/audits/mainthread-work-breakdown.js | description":["audits[mainthread-work-breakdown].description"],"lighthouse-core/audits/bootup-time.js | title":["audits[bootup-time].title"],"lighthouse-core/audits/bootup-time.js | description":["audits[bootup-time].description"],"lighthouse-core/audits/uses-rel-preload.js | title":["audits[uses-rel-preload].title"],"lighthouse-core/audits/uses-rel-preload.js | description":["audits[uses-rel-preload].description"],"lighthouse-core/audits/uses-rel-preconnect.js | title":["audits[uses-rel-preconnect].title"],"lighthouse-core/audits/uses-rel-preconnect.js | description":["audits[uses-rel-preconnect].description"],"lighthouse-core/audits/font-display.js | title":["audits[font-display].title"],"lighthouse-core/audits/font-display.js | description":["audits[font-display].description"],"lighthouse-core/audits/network-rtt.js | title":["audits[network-rtt].title"],"lighthouse-core/audits/network-rtt.js | description":["audits[network-rtt].description"],"lighthouse-core/audits/network-server-latency.js | title":["audits[network-server-latency].title"],"lighthouse-core/audits/network-server-latency.js | description":["audits[network-server-latency].description"],"lighthouse-core/audits/offline-start-url.js | title":["audits[offline-start-url].title"],"lighthouse-core/audits/offline-start-url.js | description":["audits[offline-start-url].description"],"lighthouse-core/audits/performance-budget.js | title":["audits[performance-budget].title"],"lighthouse-core/audits/performance-budget.js | description":["audits[performance-budget].description"],"lighthouse-core/audits/resource-summary.js | title":["audits[resource-summary].title"],"lighthouse-core/audits/resource-summary.js | description":["audits[resource-summary].description"],"lighthouse-core/audits/third-party-summary.js | title":["audits[third-party-summary].title"],"lighthouse-core/audits/third-party-summary.js | description":["audits[third-party-summary].description"],"lighthouse-core/audits/manual/pwa-cross-browser.js | title":["audits[pwa-cross-browser].title"],"lighthouse-core/audits/manual/pwa-cross-browser.js | description":["audits[pwa-cross-browser].description"],"lighthouse-core/audits/manual/pwa-page-transitions.js | title":["audits[pwa-page-transitions].title"],"lighthouse-core/audits/manual/pwa-page-transitions.js | description":["audits[pwa-page-transitions].description"],"lighthouse-core/audits/manual/pwa-each-page-has-url.js | title":["audits[pwa-each-page-has-url].title"],"lighthouse-core/audits/manual/pwa-each-page-has-url.js | description":["audits[pwa-each-page-has-url].description"],"lighthouse-core/audits/accessibility/accesskeys.js | title":["audits.accesskeys.title"],"lighthouse-core/audits/accessibility/accesskeys.js | description":["audits.accesskeys.description"],"lighthouse-core/audits/accessibility/aria-allowed-attr.js | title":["audits[aria-allowed-attr].title"],"lighthouse-core/audits/accessibility/aria-allowed-attr.js | description":["audits[aria-allowed-attr].description"],"lighthouse-core/audits/accessibility/aria-required-attr.js | title":["audits[aria-required-attr].title"],"lighthouse-core/audits/accessibility/aria-required-attr.js | description":["audits[aria-required-attr].description"],"lighthouse-core/audits/accessibility/aria-required-children.js | title":["audits[aria-required-children].title"],"lighthouse-core/audits/accessibility/aria-required-children.js | description":["audits[aria-required-children].description"],"lighthouse-core/audits/accessibility/aria-required-parent.js | title":["audits[aria-required-parent].title"],"lighthouse-core/audits/accessibility/aria-required-parent.js | description":["audits[aria-required-parent].description"],"lighthouse-core/audits/accessibility/aria-roles.js | title":["audits[aria-roles].title"],"lighthouse-core/audits/accessibility/aria-roles.js | description":["audits[aria-roles].description"],"lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title":["audits[aria-valid-attr-value].title"],"lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description":["audits[aria-valid-attr-value].description"],"lighthouse-core/audits/accessibility/aria-valid-attr.js | title":["audits[aria-valid-attr].title"],"lighthouse-core/audits/accessibility/aria-valid-attr.js | description":["audits[aria-valid-attr].description"],"lighthouse-core/audits/accessibility/audio-caption.js | title":["audits[audio-caption].title"],"lighthouse-core/audits/accessibility/audio-caption.js | description":["audits[audio-caption].description"],"lighthouse-core/audits/accessibility/button-name.js | title":["audits[button-name].title"],"lighthouse-core/audits/accessibility/button-name.js | description":["audits[button-name].description"],"lighthouse-core/audits/accessibility/bypass.js | title":["audits.bypass.title"],"lighthouse-core/audits/accessibility/bypass.js | description":["audits.bypass.description"],"lighthouse-core/audits/accessibility/color-contrast.js | title":["audits[color-contrast].title"],"lighthouse-core/audits/accessibility/color-contrast.js | description":["audits[color-contrast].description"],"lighthouse-core/audits/accessibility/definition-list.js | title":["audits[definition-list].title"],"lighthouse-core/audits/accessibility/definition-list.js | description":["audits[definition-list].description"],"lighthouse-core/audits/accessibility/dlitem.js | title":["audits.dlitem.title"],"lighthouse-core/audits/accessibility/dlitem.js | description":["audits.dlitem.description"],"lighthouse-core/audits/accessibility/document-title.js | title":["audits[document-title].title"],"lighthouse-core/audits/accessibility/document-title.js | description":["audits[document-title].description"],"lighthouse-core/audits/accessibility/duplicate-id.js | title":["audits[duplicate-id].title"],"lighthouse-core/audits/accessibility/duplicate-id.js | description":["audits[duplicate-id].description"],"lighthouse-core/audits/accessibility/frame-title.js | title":["audits[frame-title].title"],"lighthouse-core/audits/accessibility/frame-title.js | description":["audits[frame-title].description"],"lighthouse-core/audits/accessibility/html-has-lang.js | title":["audits[html-has-lang].title"],"lighthouse-core/audits/accessibility/html-has-lang.js | description":["audits[html-has-lang].description"],"lighthouse-core/audits/accessibility/html-lang-valid.js | title":["audits[html-lang-valid].title"],"lighthouse-core/audits/accessibility/html-lang-valid.js | description":["audits[html-lang-valid].description"],"lighthouse-core/audits/accessibility/image-alt.js | title":["audits[image-alt].title"],"lighthouse-core/audits/accessibility/image-alt.js | description":["audits[image-alt].description"],"lighthouse-core/audits/accessibility/input-image-alt.js | title":["audits[input-image-alt].title"],"lighthouse-core/audits/accessibility/input-image-alt.js | description":["audits[input-image-alt].description"],"lighthouse-core/audits/accessibility/label.js | title":["audits.label.title"],"lighthouse-core/audits/accessibility/label.js | description":["audits.label.description"],"lighthouse-core/audits/accessibility/layout-table.js | title":["audits[layout-table].title"],"lighthouse-core/audits/accessibility/layout-table.js | description":["audits[layout-table].description"],"lighthouse-core/audits/accessibility/link-name.js | title":["audits[link-name].title"],"lighthouse-core/audits/accessibility/link-name.js | description":["audits[link-name].description"],"lighthouse-core/audits/accessibility/list.js | title":["audits.list.title"],"lighthouse-core/audits/accessibility/list.js | description":["audits.list.description"],"lighthouse-core/audits/accessibility/listitem.js | title":["audits.listitem.title"],"lighthouse-core/audits/accessibility/listitem.js | description":["audits.listitem.description"],"lighthouse-core/audits/accessibility/meta-refresh.js | title":["audits[meta-refresh].title"],"lighthouse-core/audits/accessibility/meta-refresh.js | description":["audits[meta-refresh].description"],"lighthouse-core/audits/accessibility/meta-viewport.js | title":["audits[meta-viewport].title"],"lighthouse-core/audits/accessibility/meta-viewport.js | description":["audits[meta-viewport].description"],"lighthouse-core/audits/accessibility/object-alt.js | title":["audits[object-alt].title"],"lighthouse-core/audits/accessibility/object-alt.js | description":["audits[object-alt].description"],"lighthouse-core/audits/accessibility/tabindex.js | title":["audits.tabindex.title"],"lighthouse-core/audits/accessibility/tabindex.js | description":["audits.tabindex.description"],"lighthouse-core/audits/accessibility/td-headers-attr.js | title":["audits[td-headers-attr].title"],"lighthouse-core/audits/accessibility/td-headers-attr.js | description":["audits[td-headers-attr].description"],"lighthouse-core/audits/accessibility/th-has-data-cells.js | title":["audits[th-has-data-cells].title"],"lighthouse-core/audits/accessibility/th-has-data-cells.js | description":["audits[th-has-data-cells].description"],"lighthouse-core/audits/accessibility/valid-lang.js | title":["audits[valid-lang].title"],"lighthouse-core/audits/accessibility/valid-lang.js | description":["audits[valid-lang].description"],"lighthouse-core/audits/accessibility/video-caption.js | title":["audits[video-caption].title"],"lighthouse-core/audits/accessibility/video-caption.js | description":["audits[video-caption].description"],"lighthouse-core/audits/accessibility/video-description.js | title":["audits[video-description].title"],"lighthouse-core/audits/accessibility/video-description.js | description":["audits[video-description].description"],"lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | title":["audits[uses-long-cache-ttl].title"],"lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description":["audits[uses-long-cache-ttl].description"],"lighthouse-core/audits/byte-efficiency/total-byte-weight.js | title":["audits[total-byte-weight].title"],"lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description":["audits[total-byte-weight].description"],"lighthouse-core/audits/byte-efficiency/offscreen-images.js | title":["audits[offscreen-images].title"],"lighthouse-core/audits/byte-efficiency/offscreen-images.js | description":["audits[offscreen-images].description"],"lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title":["audits[render-blocking-resources].title"],"lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description":["audits[render-blocking-resources].description"],"lighthouse-core/audits/byte-efficiency/unminified-css.js | title":["audits[unminified-css].title"],"lighthouse-core/audits/byte-efficiency/unminified-css.js | description":["audits[unminified-css].description"],"lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title":["audits[unminified-javascript].title"],"lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description":["audits[unminified-javascript].description"],"lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title":["audits[unused-css-rules].title"],"lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description":["audits[unused-css-rules].description"],"lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title":["audits[uses-webp-images].title"],"lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description":["audits[uses-webp-images].description"],"lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title":["audits[uses-optimized-images].title"],"lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description":["audits[uses-optimized-images].description"],"lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title":["audits[uses-text-compression].title"],"lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description":["audits[uses-text-compression].description"],"lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title":["audits[uses-responsive-images].title"],"lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description":["audits[uses-responsive-images].description"],"lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title":["audits[efficient-animated-content].title"],"lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description":["audits[efficient-animated-content].description"],"lighthouse-core/audits/dobetterweb/appcache-manifest.js | title":["audits[appcache-manifest].title"],"lighthouse-core/audits/dobetterweb/appcache-manifest.js | description":["audits[appcache-manifest].description"],"lighthouse-core/audits/dobetterweb/doctype.js | title":["audits.doctype.title"],"lighthouse-core/audits/dobetterweb/doctype.js | description":["audits.doctype.description"],"lighthouse-core/audits/dobetterweb/dom-size.js | title":["audits[dom-size].title"],"lighthouse-core/audits/dobetterweb/dom-size.js | description":["audits[dom-size].description"],"lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title":["audits[external-anchors-use-rel-noopener].title"],"lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description":["audits[external-anchors-use-rel-noopener].description"],"lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title":["audits[geolocation-on-start].title"],"lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description":["audits[geolocation-on-start].description"],"lighthouse-core/audits/dobetterweb/no-document-write.js | title":["audits[no-document-write].title"],"lighthouse-core/audits/dobetterweb/no-document-write.js | description":["audits[no-document-write].description"],"lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title":["audits[no-vulnerable-libraries].title"],"lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description":["audits[no-vulnerable-libraries].description"],"lighthouse-core/audits/dobetterweb/js-libraries.js | title":["audits[js-libraries].title"],"lighthouse-core/audits/dobetterweb/js-libraries.js | description":["audits[js-libraries].description"],"lighthouse-core/audits/dobetterweb/notification-on-start.js | title":["audits[notification-on-start].title"],"lighthouse-core/audits/dobetterweb/notification-on-start.js | description":["audits[notification-on-start].description"],"lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title":["audits[password-inputs-can-be-pasted-into].title"],"lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description":["audits[password-inputs-can-be-pasted-into].description"],"lighthouse-core/audits/dobetterweb/uses-http2.js | title":["audits[uses-http2].title"],"lighthouse-core/audits/dobetterweb/uses-http2.js | description":["audits[uses-http2].description"],"lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title":["audits[uses-passive-event-listeners].title"],"lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description":["audits[uses-passive-event-listeners].description"],"lighthouse-core/audits/seo/meta-description.js | title":["audits[meta-description].title"],"lighthouse-core/audits/seo/meta-description.js | description":["audits[meta-description].description"],"lighthouse-core/audits/seo/http-status-code.js | title":["audits[http-status-code].title"],"lighthouse-core/audits/seo/http-status-code.js | description":["audits[http-status-code].description"],"lighthouse-core/audits/seo/font-size.js | title":["audits[font-size].title"],"lighthouse-core/audits/seo/font-size.js | description":["audits[font-size].description"],"lighthouse-core/audits/seo/link-text.js | title":["audits[link-text].title"],"lighthouse-core/audits/seo/link-text.js | description":["audits[link-text].description"],"lighthouse-core/audits/seo/is-crawlable.js | title":["audits[is-crawlable].title"],"lighthouse-core/audits/seo/is-crawlable.js | description":["audits[is-crawlable].description"],"lighthouse-core/audits/seo/robots-txt.js | title":["audits[robots-txt].title"],"lighthouse-core/audits/seo/robots-txt.js | description":["audits[robots-txt].description"],"lighthouse-core/audits/seo/tap-targets.js | title":["audits[tap-targets].title"],"lighthouse-core/audits/seo/tap-targets.js | description":["audits[tap-targets].description"],"lighthouse-core/audits/seo/hreflang.js | title":["audits.hreflang.title"],"lighthouse-core/audits/seo/hreflang.js | description":["audits.hreflang.description"],"lighthouse-core/audits/seo/plugins.js | title":["audits.plugins.title"],"lighthouse-core/audits/seo/plugins.js | description":["audits.plugins.description"],"lighthouse-core/audits/seo/canonical.js | title":["audits.canonical.title"],"lighthouse-core/audits/seo/canonical.js | description":["audits.canonical.description"],"lighthouse-core/audits/seo/manual/structured-data.js | title":["audits[structured-data].title"],"lighthouse-core/audits/seo/manual/structured-data.js | description":["audits[structured-data].description"],"lighthouse-core/config/default-config.js | performanceCategoryTitle":["categories.performance.title"],"lighthouse-core/config/default-config.js | a11yCategoryTitle":["categories.accessibility.title"],"lighthouse-core/config/default-config.js | a11yCategoryDescription":["categories.accessibility.description"],"lighthouse-core/config/default-config.js | a11yCategoryManualDescription":["categories.accessibility.manualDescription"],"lighthouse-core/config/default-config.js | bestPracticesCategoryTitle":["categories[best-practices].title"],"lighthouse-core/config/default-config.js | seoCategoryTitle":["categories.seo.title"],"lighthouse-core/config/default-config.js | seoCategoryDescription":["categories.seo.description"],"lighthouse-core/config/default-config.js | seoCategoryManualDescription":["categories.seo.manualDescription"],"lighthouse-core/config/default-config.js | pwaCategoryTitle":["categories.pwa.title"],"lighthouse-core/config/default-config.js | pwaCategoryDescription":["categories.pwa.description"],"lighthouse-core/config/default-config.js | pwaCategoryManualDescription":["categories.pwa.manualDescription"],"lighthouse-core/config/default-config.js | metricGroupTitle":["categoryGroups.metrics.title"],"lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle":["categoryGroups[load-opportunities].title"],"lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription":["categoryGroups[load-opportunities].description"],"lighthouse-core/config/default-config.js | budgetsGroupTitle":["categoryGroups.budgets.title"],"lighthouse-core/config/default-config.js | budgetsGroupDescription":["categoryGroups.budgets.description"],"lighthouse-core/config/default-config.js | diagnosticsGroupTitle":["categoryGroups.diagnostics.title"],"lighthouse-core/config/default-config.js | diagnosticsGroupDescription":["categoryGroups.diagnostics.description"],"lighthouse-core/config/default-config.js | pwaFastReliableGroupTitle":["categoryGroups[pwa-fast-reliable].title"],"lighthouse-core/config/default-config.js | pwaInstallableGroupTitle":["categoryGroups[pwa-installable].title"],"lighthouse-core/config/default-config.js | pwaOptimizedGroupTitle":["categoryGroups[pwa-optimized].title"],"lighthouse-core/config/default-config.js | a11yBestPracticesGroupTitle":["categoryGroups[a11y-best-practices].title"],"lighthouse-core/config/default-config.js | a11yBestPracticesGroupDescription":["categoryGroups[a11y-best-practices].description"],"lighthouse-core/config/default-config.js | a11yColorContrastGroupTitle":["categoryGroups[a11y-color-contrast].title"],"lighthouse-core/config/default-config.js | a11yColorContrastGroupDescription":["categoryGroups[a11y-color-contrast].description"],"lighthouse-core/config/default-config.js | a11yNamesLabelsGroupTitle":["categoryGroups[a11y-names-labels].title"],"lighthouse-core/config/default-config.js | a11yNamesLabelsGroupDescription":["categoryGroups[a11y-names-labels].description"],"lighthouse-core/config/default-config.js | a11yNavigationGroupTitle":["categoryGroups[a11y-navigation].title"],"lighthouse-core/config/default-config.js | a11yNavigationGroupDescription":["categoryGroups[a11y-navigation].description"],"lighthouse-core/config/default-config.js | a11yAriaGroupTitle":["categoryGroups[a11y-aria].title"],"lighthouse-core/config/default-config.js | a11yAriaGroupDescription":["categoryGroups[a11y-aria].description"],"lighthouse-core/config/default-config.js | a11yLanguageGroupTitle":["categoryGroups[a11y-language].title"],"lighthouse-core/config/default-config.js | a11yLanguageGroupDescription":["categoryGroups[a11y-language].description"],"lighthouse-core/config/default-config.js | a11yAudioVideoGroupTitle":["categoryGroups[a11y-audio-video].title"],"lighthouse-core/config/default-config.js | a11yAudioVideoGroupDescription":["categoryGroups[a11y-audio-video].description"],"lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle":["categoryGroups[a11y-tables-lists].title"],"lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupDescription":["categoryGroups[a11y-tables-lists].description"],"lighthouse-core/config/default-config.js | seoMobileGroupTitle":["categoryGroups[seo-mobile].title"],"lighthouse-core/config/default-config.js | seoMobileGroupDescription":["categoryGroups[seo-mobile].description"],"lighthouse-core/config/default-config.js | seoContentGroupTitle":["categoryGroups[seo-content].title"],"lighthouse-core/config/default-config.js | seoContentGroupDescription":["categoryGroups[seo-content].description"],"lighthouse-core/config/default-config.js | seoCrawlingGroupTitle":["categoryGroups[seo-crawl].title"],"lighthouse-core/config/default-config.js | seoCrawlingGroupDescription":["categoryGroups[seo-crawl].description"]}},"stackPacks":[]};</script>
+  <script>
+    function __initLighthouseReport__() {
+      const dom = new DOM(document);
+      const renderer = new ReportRenderer(dom);
+
+      const container = document.querySelector('main');
+      renderer.renderReport(window.__LIGHTHOUSE_JSON__, container);
+
+      // Hook in JS features and page-level event listeners after the report
+      // is in the document.
+      const features = new ReportUIFeatures(dom);
+      features.initFeatures(window.__LIGHTHOUSE_JSON__);
+    }
+    window.addEventListener('DOMContentLoaded', __initLighthouseReport__);
+
+    document.addEventListener('lh-analytics', e => {
+      if (window.ga) {
+        ga(e.detail.cmd, e.detail.fields);
+      }
+    });
+
+    document.addEventListener('lh-log', e => {
+      const logger = new Logger(document.querySelector('#lh-log'));
+
+      switch (e.detail.cmd) {
+        case 'log':
+          logger.log(e.detail.msg);
+          break;
+        case 'warn':
+          logger.warn(e.detail.msg);
+          break;
+        case 'error':
+          logger.error(e.detail.msg);
+          break;
+        case 'hide':
+          logger.hide();
+          break;
+      }
+    });
+  </script>
+</body>
+</html>

--- a/results/5.6.0.json
+++ b/results/5.6.0.json
@@ -1,0 +1,4470 @@
+{
+  "userAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/80.0.3987.0 Safari/537.36",
+  "environment": {
+    "networkUserAgent": "",
+    "hostUserAgent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/80.0.3987.0 Safari/537.36",
+    "benchmarkIndex": 92
+  },
+  "lighthouseVersion": "5.6.0",
+  "fetchTime": "2020-03-12T20:05:26.605Z",
+  "requestedUrl": "https://example.com/",
+  "finalUrl": "https://example.com/",
+  "runWarnings": [
+    "Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests. (Details: net::ERR_CERT_AUTHORITY_INVALID)"
+  ],
+  "runtimeError": {
+    "code": "FAILED_DOCUMENT_REQUEST",
+    "message": "Lighthouse was unable to reliably load the page you requested. Make sure you are testing the correct URL and that the server is properly responding to all requests. (Details: net::ERR_CERT_AUTHORITY_INVALID)"
+  },
+  "audits": {
+    "is-on-https": {
+      "id": "is-on-https",
+      "title": "Uses HTTPS",
+      "description": "All sites should be protected with HTTPS, even ones that don't handle sensitive data. HTTPS prevents intruders from tampering with or passively listening in on the communications between your app and your users, and is a prerequisite for HTTP/2 and many new web platform APIs. [Learn more](https://web.dev/is-on-https).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "redirects-http": {
+      "id": "redirects-http",
+      "title": "Redirects HTTP traffic to HTTPS",
+      "description": "If you've already set up HTTPS, make sure that you redirect all HTTP traffic to HTTPS in order to enable secure web features for all your users. [Learn more](https://web.dev/redirects-http).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required HTTPRedirect gatherer did not run."
+    },
+    "service-worker": {
+      "id": "service-worker",
+      "title": "Registers a service worker that controls page and `start_url`",
+      "description": "The service worker is the technology that enables your app to use many Progressive Web App features, such as offline, add to homescreen, and push notifications. [Learn more](https://web.dev/service-worker).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ServiceWorker gatherer did not run."
+    },
+    "works-offline": {
+      "id": "works-offline",
+      "title": "Current page responds with a 200 when offline",
+      "description": "If you're building a Progressive Web App, consider using a service worker so that your app can work offline. [Learn more](https://web.dev/works-offline).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Offline gatherer did not run."
+    },
+    "viewport": {
+      "id": "viewport",
+      "title": "Has a `<meta name=\"viewport\">` tag with `width` or `initial-scale`",
+      "description": "Add a `<meta name=\"viewport\">` tag to optimize your app for mobile screens. [Learn more](https://web.dev/viewport).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required MetaElements gatherer did not run."
+    },
+    "without-javascript": {
+      "id": "without-javascript",
+      "title": "Contains some content when JavaScript is not available",
+      "description": "Your app should display some content when JavaScript is disabled, even if it's just a warning to the user that JavaScript is required to use the app. [Learn more](https://web.dev/without-javascript).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required HTMLWithoutJavaScript gatherer did not run."
+    },
+    "first-contentful-paint": {
+      "id": "first-contentful-paint",
+      "title": "First Contentful Paint",
+      "description": "First Contentful Paint marks the time at which the first text or image is painted. [Learn more](https://web.dev/first-contentful-paint).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "first-meaningful-paint": {
+      "id": "first-meaningful-paint",
+      "title": "First Meaningful Paint",
+      "description": "First Meaningful Paint measures when the primary content of a page is visible. [Learn more](https://web.dev/first-meaningful-paint).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "load-fast-enough-for-pwa": {
+      "id": "load-fast-enough-for-pwa",
+      "title": "Page load is fast enough on mobile networks",
+      "description": "A fast page load over a cellular network ensures a good mobile user experience. [Learn more](https://web.dev/load-fast-enough-for-pwa).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "speed-index": {
+      "id": "speed-index",
+      "title": "Speed Index",
+      "description": "Speed Index shows how quickly the contents of a page are visibly populated. [Learn more](https://web.dev/speed-index).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "screenshot-thumbnails": {
+      "id": "screenshot-thumbnails",
+      "title": "Screenshot Thumbnails",
+      "description": "This is what the load of your site looked like.",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "final-screenshot": {
+      "id": "final-screenshot",
+      "title": "Final Screenshot",
+      "description": "The last screenshot captured of the pageload.",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "estimated-input-latency": {
+      "id": "estimated-input-latency",
+      "title": "Estimated Input Latency",
+      "description": "Estimated Input Latency is an estimate of how long your app takes to respond to user input, in milliseconds, during the busiest 5s window of page load. If your latency is higher than 50 ms, users may perceive your app as laggy. [Learn more](https://web.dev/estimated-input-latency).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "total-blocking-time": {
+      "id": "total-blocking-time",
+      "title": "Total Blocking Time",
+      "description": "Sum of all time periods between FCP and Time to Interactive, when task length exceeded 50ms, expressed in milliseconds.",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "max-potential-fid": {
+      "id": "max-potential-fid",
+      "title": "Max Potential First Input Delay",
+      "description": "The maximum potential First Input Delay that your users could experience is the duration, in milliseconds, of the longest task. [Learn more](https://developers.google.com/web/updates/2018/05/first-input-delay).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "errors-in-console": {
+      "id": "errors-in-console",
+      "title": "No browser errors logged to the console",
+      "description": "Errors logged to the console indicate unresolved problems. They can come from network request failures and other browser concerns. [Learn more](https://web.dev/errors-in-console)",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ConsoleMessages gatherer did not run."
+    },
+    "time-to-first-byte": {
+      "id": "time-to-first-byte",
+      "title": "Server response times are low (TTFB)",
+      "description": "Time To First Byte identifies the time at which your server sends a response. [Learn more](https://web.dev/time-to-first-byte).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "first-cpu-idle": {
+      "id": "first-cpu-idle",
+      "title": "First CPU Idle",
+      "description": "First CPU Idle marks the first time at which the page's main thread is quiet enough to handle input.  [Learn more](https://web.dev/first-cpu-idle).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "interactive": {
+      "id": "interactive",
+      "title": "Time to Interactive",
+      "description": "Time to interactive is the amount of time it takes for the page to become fully interactive. [Learn more](https://web.dev/interactive).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "user-timings": {
+      "id": "user-timings",
+      "title": "User Timing marks and measures",
+      "description": "Consider instrumenting your app with the User Timing API to measure your app's real-world performance during key user experiences. [Learn more](https://web.dev/user-timings).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "critical-request-chains": {
+      "id": "critical-request-chains",
+      "title": "Avoid chaining critical requests",
+      "description": "The Critical Request Chains below show you what resources are loaded with a high priority. Consider reducing the length of chains, reducing the download size of resources, or deferring the download of unnecessary resources to improve page load. [Learn more](https://web.dev/critical-request-chains).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "redirects": {
+      "id": "redirects",
+      "title": "Avoid multiple page redirects",
+      "description": "Redirects introduce additional delays before the page can be loaded. [Learn more](https://web.dev/redirects).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "installable-manifest": {
+      "id": "installable-manifest",
+      "title": "Web app manifest does not meet the installability requirements",
+      "description": "Browsers can proactively prompt users to add your app to their homescreen, which can lead to higher engagement. [Learn more](https://web.dev/installable-manifest).",
+      "score": 0,
+      "scoreDisplayMode": "binary",
+      "explanation": "Failures: No manifest was fetched.",
+      "details": {
+        "type": "debugdata",
+        "items": [
+          {
+            "failures": [
+              "No manifest was fetched"
+            ],
+            "isParseFailure": true,
+            "parseFailureReason": "No manifest was fetched"
+          }
+        ]
+      }
+    },
+    "apple-touch-icon": {
+      "id": "apple-touch-icon",
+      "title": "Provides a valid `apple-touch-icon`",
+      "description": "For ideal appearance on iOS when users add a progressive web app to the home screen, define an `apple-touch-icon`. It must point to a non-transparent 192px (or 180px) square PNG. [Learn More](https://web.dev/apple-touch-icon/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required LinkElements gatherer did not run."
+    },
+    "splash-screen": {
+      "id": "splash-screen",
+      "title": "Is not configured for a custom splash screen",
+      "description": "A themed splash screen ensures a high-quality experience when users launch your app from their homescreens. [Learn more](https://web.dev/splash-screen).",
+      "score": 0,
+      "scoreDisplayMode": "binary",
+      "explanation": "Failures: No manifest was fetched.",
+      "details": {
+        "type": "debugdata",
+        "items": [
+          {
+            "failures": [
+              "No manifest was fetched"
+            ],
+            "isParseFailure": true,
+            "parseFailureReason": "No manifest was fetched"
+          }
+        ]
+      }
+    },
+    "themed-omnibox": {
+      "id": "themed-omnibox",
+      "title": "Sets a theme color for the address bar.",
+      "description": "The browser address bar can be themed to match your site. [Learn more](https://web.dev/themed-omnibox).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required MetaElements gatherer did not run."
+    },
+    "content-width": {
+      "id": "content-width",
+      "title": "Content is sized correctly for the viewport",
+      "description": "If the width of your app's content doesn't match the width of the viewport, your app might not be optimized for mobile screens. [Learn more](https://web.dev/content-width).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ViewportDimensions gatherer did not run."
+    },
+    "image-aspect-ratio": {
+      "id": "image-aspect-ratio",
+      "title": "Displays images with correct aspect ratio",
+      "description": "Image display dimensions should match natural aspect ratio. [Learn more](https://web.dev/image-aspect-ratio).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ImageElements gatherer did not run."
+    },
+    "deprecations": {
+      "id": "deprecations",
+      "title": "Avoids deprecated APIs",
+      "description": "Deprecated APIs will eventually be removed from the browser. [Learn more](https://web.dev/deprecations).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ConsoleMessages gatherer did not run."
+    },
+    "mainthread-work-breakdown": {
+      "id": "mainthread-work-breakdown",
+      "title": "Minimizes main-thread work",
+      "description": "Consider reducing the time spent parsing, compiling and executing JS. You may find delivering smaller JS payloads helps with this. [Learn more](https://web.dev/mainthread-work-breakdown)",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "bootup-time": {
+      "id": "bootup-time",
+      "title": "JavaScript execution time",
+      "description": "Consider reducing the time spent parsing, compiling, and executing JS. You may find delivering smaller JS payloads helps with this. [Learn more](https://web.dev/bootup-time).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "uses-rel-preload": {
+      "id": "uses-rel-preload",
+      "title": "Preload key requests",
+      "description": "Consider using `<link rel=preload>` to prioritize fetching resources that are currently requested later in page load. [Learn more](https://web.dev/uses-rel-preload).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "uses-rel-preconnect": {
+      "id": "uses-rel-preconnect",
+      "title": "Preconnect to required origins",
+      "description": "Consider adding `preconnect` or `dns-prefetch` resource hints to establish early connections to important third-party origins. [Learn more](https://web.dev/uses-rel-preconnect).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "font-display": {
+      "id": "font-display",
+      "title": "All text remains visible during webfont loads",
+      "description": "Leverage the font-display CSS feature to ensure text is user-visible while webfonts are loading. [Learn more](https://web.dev/font-display).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "diagnostics": {
+      "id": "diagnostics",
+      "title": "Diagnostics",
+      "description": "Collection of useful page vitals.",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "network-requests": {
+      "id": "network-requests",
+      "title": "Network Requests",
+      "description": "Lists the network requests that were made during page load.",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "network-rtt": {
+      "id": "network-rtt",
+      "title": "Network Round Trip Times",
+      "description": "Network round trip times (RTT) have a large impact on performance. If the RTT to an origin is high, it's an indication that servers closer to the user could improve performance. [Learn more](https://hpbn.co/primer-on-latency-and-bandwidth/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "network-server-latency": {
+      "id": "network-server-latency",
+      "title": "Server Backend Latencies",
+      "description": "Server latencies can impact web performance. If the server latency of an origin is high, it's an indication the server is overloaded or has poor backend performance. [Learn more](https://hpbn.co/primer-on-web-performance/#analyzing-the-resource-waterfall).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "main-thread-tasks": {
+      "id": "main-thread-tasks",
+      "title": "Tasks",
+      "description": "Lists the toplevel main thread tasks that executed during page load.",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "metrics": {
+      "id": "metrics",
+      "title": "Metrics",
+      "description": "Collects all available metrics.",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "offline-start-url": {
+      "id": "offline-start-url",
+      "title": "`start_url` responds with a 200 when offline",
+      "description": "A service worker enables your web app to be reliable in unpredictable network conditions. [Learn more](https://web.dev/offline-start-url).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required StartUrl gatherer did not run."
+    },
+    "performance-budget": {
+      "id": "performance-budget",
+      "title": "Performance budget",
+      "description": "Keep the quantity and size of network requests under the targets set by the provided performance budget. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/budgets).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "resource-summary": {
+      "id": "resource-summary",
+      "title": "Keep request counts low and transfer sizes small",
+      "description": "To set budgets for the quantity and size of page resources, add a budget.json file. [Learn more](https://developers.google.com/web/tools/lighthouse/audits/budgets).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "third-party-summary": {
+      "id": "third-party-summary",
+      "title": "Minimize third-party usage",
+      "description": "Third-party code can significantly impact load performance. Limit the number of redundant third-party providers and try to load third-party code after your page has primarily finished loading. [Learn more](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/loading-third-party-javascript/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required traces gatherer did not run."
+    },
+    "pwa-cross-browser": {
+      "id": "pwa-cross-browser",
+      "title": "Site works cross-browser",
+      "description": "To reach the most number of users, sites should work across every major browser. [Learn more](https://web.dev/pwa-cross-browser).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "pwa-page-transitions": {
+      "id": "pwa-page-transitions",
+      "title": "Page transitions don't feel like they block on the network",
+      "description": "Transitions should feel snappy as you tap around, even on a slow network. This experience is key to a user's perception of performance. [Learn more](https://web.dev/pwa-page-transitions).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "pwa-each-page-has-url": {
+      "id": "pwa-each-page-has-url",
+      "title": "Each page has a URL",
+      "description": "Ensure individual pages are deep linkable via URL and that URLs are unique for the purpose of shareability on social media. [Learn more](https://web.dev/pwa-each-page-has-url).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "accesskeys": {
+      "id": "accesskeys",
+      "title": "`[accesskey]` values are unique",
+      "description": "Access keys let users quickly focus a part of the page. For proper navigation, each access key must be unique. [Learn more](https://web.dev/accesskeys/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "aria-allowed-attr": {
+      "id": "aria-allowed-attr",
+      "title": "`[aria-*]` attributes match their roles",
+      "description": "Each ARIA `role` supports a specific subset of `aria-*` attributes. Mismatching these invalidates the `aria-*` attributes. [Learn more](https://web.dev/aria-allowed-attr/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "aria-required-attr": {
+      "id": "aria-required-attr",
+      "title": "`[role]`s have all required `[aria-*]` attributes",
+      "description": "Some ARIA roles have required attributes that describe the state of the element to screen readers. [Learn more](https://web.dev/aria-required-attr/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "aria-required-children": {
+      "id": "aria-required-children",
+      "title": "Elements with an ARIA `[role]` that require children to contain a specific `[role]` have all required children.",
+      "description": "Some ARIA parent roles must contain specific child roles to perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-children/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "aria-required-parent": {
+      "id": "aria-required-parent",
+      "title": "`[role]`s are contained by their required parent element",
+      "description": "Some ARIA child roles must be contained by specific parent roles to properly perform their intended accessibility functions. [Learn more](https://web.dev/aria-required-parent/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "aria-roles": {
+      "id": "aria-roles",
+      "title": "`[role]` values are valid",
+      "description": "ARIA roles must have valid values in order to perform their intended accessibility functions. [Learn more](https://web.dev/aria-roles/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "aria-valid-attr-value": {
+      "id": "aria-valid-attr-value",
+      "title": "`[aria-*]` attributes have valid values",
+      "description": "Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid values. [Learn more](https://web.dev/aria-valid-attr-value/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "aria-valid-attr": {
+      "id": "aria-valid-attr",
+      "title": "`[aria-*]` attributes are valid and not misspelled",
+      "description": "Assistive technologies, like screen readers, can't interpret ARIA attributes with invalid names. [Learn more](https://web.dev/aria-valid-attr/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "audio-caption": {
+      "id": "audio-caption",
+      "title": "`<audio>` elements contain a `<track>` element with `[kind=\"captions\"]`",
+      "description": "Captions make audio elements usable for deaf or hearing-impaired users, providing critical information such as who is talking, what they're saying, and other non-speech information. [Learn more](https://web.dev/audio-caption/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "button-name": {
+      "id": "button-name",
+      "title": "Buttons have an accessible name",
+      "description": "When a button doesn't have an accessible name, screen readers announce it as \"button\", making it unusable for users who rely on screen readers. [Learn more](https://web.dev/button-name/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "bypass": {
+      "id": "bypass",
+      "title": "The page contains a heading, skip link, or landmark region",
+      "description": "Adding ways to bypass repetitive content lets keyboard users navigate the page more efficiently. [Learn more](https://web.dev/bypass/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "color-contrast": {
+      "id": "color-contrast",
+      "title": "Background and foreground colors have a sufficient contrast ratio",
+      "description": "Low-contrast text is difficult or impossible for many users to read. [Learn more](https://web.dev/color-contrast/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "definition-list": {
+      "id": "definition-list",
+      "title": "`<dl>`'s contain only properly-ordered `<dt>` and `<dd>` groups, `<script>` or `<template>` elements.",
+      "description": "When definition lists are not properly marked up, screen readers may produce confusing or inaccurate output. [Learn more](https://web.dev/definition-list/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "dlitem": {
+      "id": "dlitem",
+      "title": "Definition list items are wrapped in `<dl>` elements",
+      "description": "Definition list items (`<dt>` and `<dd>`) must be wrapped in a parent `<dl>` element to ensure that screen readers can properly announce them. [Learn more](https://web.dev/dlitem/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "document-title": {
+      "id": "document-title",
+      "title": "Document has a `<title>` element",
+      "description": "The title gives screen reader users an overview of the page, and search engine users rely on it heavily to determine if a page is relevant to their search. [Learn more](https://web.dev/document-title/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "duplicate-id": {
+      "id": "duplicate-id",
+      "title": "`[id]` attributes on the page are unique",
+      "description": "The value of an id attribute must be unique to prevent other instances from being overlooked by assistive technologies. [Learn more](https://web.dev/duplicate-id/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "frame-title": {
+      "id": "frame-title",
+      "title": "`<frame>` or `<iframe>` elements have a title",
+      "description": "Screen reader users rely on frame titles to describe the contents of frames. [Learn more](https://web.dev/frame-title/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "html-has-lang": {
+      "id": "html-has-lang",
+      "title": "`<html>` element has a `[lang]` attribute",
+      "description": "If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly. [Learn more](https://web.dev/html-has-lang/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "html-lang-valid": {
+      "id": "html-lang-valid",
+      "title": "`<html>` element has a valid value for its `[lang]` attribute",
+      "description": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) helps screen readers announce text properly. [Learn more](https://web.dev/html-lang-valid/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "image-alt": {
+      "id": "image-alt",
+      "title": "Image elements have `[alt]` attributes",
+      "description": "Informative elements should aim for short, descriptive alternate text. Decorative elements can be ignored with an empty alt attribute. [Learn more](https://web.dev/image-alt/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "input-image-alt": {
+      "id": "input-image-alt",
+      "title": "`<input type=\"image\">` elements have `[alt]` text",
+      "description": "When an image is being used as an `<input>` button, providing alternative text can help screen reader users understand the purpose of the button. [Learn more](https://web.dev/input-image-alt/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "label": {
+      "id": "label",
+      "title": "Form elements have associated labels",
+      "description": "Labels ensure that form controls are announced properly by assistive technologies, like screen readers. [Learn more](https://web.dev/label/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "layout-table": {
+      "id": "layout-table",
+      "title": "Presentational `<table>` elements avoid using `<th>`, `<caption>` or the `[summary]` attribute.",
+      "description": "A table being used for layout purposes should not include data elements, such as the th or caption elements or the summary attribute, because this can create a confusing experience for screen reader users. [Learn more](https://web.dev/layout-table/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "link-name": {
+      "id": "link-name",
+      "title": "Links have a discernible name",
+      "description": "Link text (and alternate text for images, when used as links) that is discernible, unique, and focusable improves the navigation experience for screen reader users. [Learn more](https://web.dev/link-name/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "list": {
+      "id": "list",
+      "title": "Lists contain only `<li>` elements and script supporting elements (`<script>` and `<template>`).",
+      "description": "Screen readers have a specific way of announcing lists. Ensuring proper list structure aids screen reader output. [Learn more](https://web.dev/list/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "listitem": {
+      "id": "listitem",
+      "title": "List items (`<li>`) are contained within `<ul>` or `<ol>` parent elements",
+      "description": "Screen readers require list items (`<li>`) to be contained within a parent `<ul>` or `<ol>` to be announced properly. [Learn more](https://web.dev/listitem/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "meta-refresh": {
+      "id": "meta-refresh",
+      "title": "The document does not use `<meta http-equiv=\"refresh\">`",
+      "description": "Users do not expect a page to refresh automatically, and doing so will move focus back to the top of the page. This may create a frustrating or confusing experience. [Learn more](https://web.dev/meta-refresh/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "meta-viewport": {
+      "id": "meta-viewport",
+      "title": "`[user-scalable=\"no\"]` is not used in the `<meta name=\"viewport\">` element and the `[maximum-scale]` attribute is not less than 5.",
+      "description": "Disabling zooming is problematic for users with low vision who rely on screen magnification to properly see the contents of a web page. [Learn more](https://web.dev/meta-viewport/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "object-alt": {
+      "id": "object-alt",
+      "title": "`<object>` elements have `[alt]` text",
+      "description": "Screen readers cannot translate non-text content. Adding alt text to `<object>` elements helps screen readers convey meaning to users. [Learn more](https://web.dev/object-alt/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "tabindex": {
+      "id": "tabindex",
+      "title": "No element has a `[tabindex]` value greater than 0",
+      "description": "A value greater than 0 implies an explicit navigation ordering. Although technically valid, this often creates frustrating experiences for users who rely on assistive technologies. [Learn more](https://web.dev/tabindex/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "td-headers-attr": {
+      "id": "td-headers-attr",
+      "title": "Cells in a `<table>` element that use the `[headers]` attribute refer to table cells within the same table.",
+      "description": "Screen readers have features to make navigating tables easier. Ensuring `<td>` cells using the `[headers]` attribute only refer to other cells in the same table may improve the experience for screen reader users. [Learn more](https://web.dev/td-headers-attr/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "th-has-data-cells": {
+      "id": "th-has-data-cells",
+      "title": "`<th>` elements and elements with `[role=\"columnheader\"/\"rowheader\"]` have data cells they describe.",
+      "description": "Screen readers have features to make navigating tables easier. Ensuring table headers always refer to some set of cells may improve the experience for screen reader users. [Learn more](https://web.dev/th-has-data-cells/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "valid-lang": {
+      "id": "valid-lang",
+      "title": "`[lang]` attributes have a valid value",
+      "description": "Specifying a valid [BCP 47 language](https://www.w3.org/International/questions/qa-choosing-language-tags#question) on elements helps ensure that text is pronounced correctly by a screen reader. [Learn more](https://web.dev/valid-lang/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "video-caption": {
+      "id": "video-caption",
+      "title": "`<video>` elements contain a `<track>` element with `[kind=\"captions\"]`",
+      "description": "When a video provides a caption it is easier for deaf and hearing impaired users to access its information. [Learn more](https://web.dev/video-caption/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "video-description": {
+      "id": "video-description",
+      "title": "`<video>` elements contain a `<track>` element with `[kind=\"description\"]`",
+      "description": "Audio descriptions provide relevant information for videos that dialogue cannot, such as facial expressions and scenes. [Learn more](https://web.dev/video-description/).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Accessibility gatherer did not run."
+    },
+    "custom-controls-labels": {
+      "id": "custom-controls-labels",
+      "title": "Custom controls have associated labels",
+      "description": "Custom interactive controls have associated labels, provided by aria-label or aria-labelledby. [Learn more](https://web.dev/custom-controls-labels/).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "custom-controls-roles": {
+      "id": "custom-controls-roles",
+      "title": "Custom controls have ARIA roles",
+      "description": "Custom interactive controls have appropriate ARIA roles. [Learn more](https://web.dev/custom-control-roles/).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "focus-traps": {
+      "id": "focus-traps",
+      "title": "User focus is not accidentally trapped in a region",
+      "description": "A user can tab into and out of any control or region without accidentally trapping their focus. [Learn more](https://web.dev/focus-traps/).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "focusable-controls": {
+      "id": "focusable-controls",
+      "title": "Interactive controls are keyboard focusable",
+      "description": "Custom interactive controls are keyboard focusable and display a focus indicator. [Learn more](https://web.dev/focusable-controls/).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "heading-levels": {
+      "id": "heading-levels",
+      "title": "Headings don't skip levels",
+      "description": "Headings are used to create an outline for the page and heading levels are not skipped. [Learn more](https://web.dev/heading-levels/).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "interactive-element-affordance": {
+      "id": "interactive-element-affordance",
+      "title": "Interactive elements indicate their purpose and state",
+      "description": "Interactive elements, such as links and buttons, should indicate their state and be distinguishable from non-interactive elements. [Learn more](https://web.dev/interactive-element-affordance/).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "logical-tab-order": {
+      "id": "logical-tab-order",
+      "title": "The page has a logical tab order",
+      "description": "Tabbing through the page follows the visual layout. Users cannot focus elements that are offscreen. [Learn more](https://web.dev/logical-tab-order/).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "managed-focus": {
+      "id": "managed-focus",
+      "title": "The user's focus is directed to new content added to the page",
+      "description": "If new content, such as a dialog, is added to the page, the user's focus is directed to it. [Learn more](https://web.dev/managed-focus/).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "offscreen-content-hidden": {
+      "id": "offscreen-content-hidden",
+      "title": "Offscreen content is hidden from assistive technology",
+      "description": "Offscreen content is hidden with display: none or aria-hidden=true. [Learn more](https://web.dev/offscreen-content-hidden/).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "use-landmarks": {
+      "id": "use-landmarks",
+      "title": "HTML5 landmark elements are used to improve navigation",
+      "description": "Landmark elements (<main>, <nav>, etc.) are used to improve the keyboard navigation of the page for assistive technology. [Learn more](https://web.dev/use-landmarks/).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "visual-order-follows-dom": {
+      "id": "visual-order-follows-dom",
+      "title": "Visual order on the page follows DOM order",
+      "description": "DOM order matches the visual order, improving navigation for assistive technology. [Learn more](https://web.dev/visual-order-follows-dom/).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    },
+    "uses-long-cache-ttl": {
+      "id": "uses-long-cache-ttl",
+      "title": "Uses efficient cache policy on static assets",
+      "description": "A long cache lifetime can speed up repeat visits to your page. [Learn more](https://web.dev/uses-long-cache-ttl).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "total-byte-weight": {
+      "id": "total-byte-weight",
+      "title": "Avoids enormous network payloads",
+      "description": "Large network payloads cost users real money and are highly correlated with long load times. [Learn more](https://web.dev/total-byte-weight).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "offscreen-images": {
+      "id": "offscreen-images",
+      "title": "Defer offscreen images",
+      "description": "Consider lazy-loading offscreen and hidden images after all critical resources have finished loading to lower time to interactive. [Learn more](https://web.dev/offscreen-images).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ImageElements gatherer did not run."
+    },
+    "render-blocking-resources": {
+      "id": "render-blocking-resources",
+      "title": "Eliminate render-blocking resources",
+      "description": "Resources are blocking the first paint of your page. Consider delivering critical JS/CSS inline and deferring all non-critical JS/styles. [Learn more](https://web.dev/render-blocking-resources).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required TagsBlockingFirstPaint gatherer did not run."
+    },
+    "unminified-css": {
+      "id": "unminified-css",
+      "title": "Minify CSS",
+      "description": "Minifying CSS files can reduce network payload sizes. [Learn more](https://web.dev/unminified-css).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required CSSUsage gatherer did not run."
+    },
+    "unminified-javascript": {
+      "id": "unminified-javascript",
+      "title": "Minify JavaScript",
+      "description": "Minifying JavaScript files can reduce payload sizes and script parse time. [Learn more](https://web.dev/unminified-javascript).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ScriptElements gatherer did not run."
+    },
+    "unused-css-rules": {
+      "id": "unused-css-rules",
+      "title": "Remove unused CSS",
+      "description": "Remove dead rules from stylesheets and defer the loading of CSS not used for above-the-fold content to reduce unnecessary bytes consumed by network activity. [Learn more](https://web.dev/unused-css-rules).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required CSSUsage gatherer did not run."
+    },
+    "uses-webp-images": {
+      "id": "uses-webp-images",
+      "title": "Serve images in next-gen formats",
+      "description": "Image formats like JPEG 2000, JPEG XR, and WebP often provide better compression than PNG or JPEG, which means faster downloads and less data consumption. [Learn more](https://web.dev/uses-webp-images).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required OptimizedImages gatherer did not run."
+    },
+    "uses-optimized-images": {
+      "id": "uses-optimized-images",
+      "title": "Efficiently encode images",
+      "description": "Optimized images load faster and consume less cellular data. [Learn more](https://web.dev/uses-optimized-images).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required OptimizedImages gatherer did not run."
+    },
+    "uses-text-compression": {
+      "id": "uses-text-compression",
+      "title": "Enable text compression",
+      "description": "Text-based resources should be served with compression (gzip, deflate or brotli) to minimize total network bytes. [Learn more](https://web.dev/uses-text-compression).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ResponseCompression gatherer did not run."
+    },
+    "uses-responsive-images": {
+      "id": "uses-responsive-images",
+      "title": "Properly size images",
+      "description": "Serve images that are appropriately-sized to save cellular data and improve load time. [Learn more](https://web.dev/uses-responsive-images).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ImageElements gatherer did not run."
+    },
+    "efficient-animated-content": {
+      "id": "efficient-animated-content",
+      "title": "Use video formats for animated content",
+      "description": "Large GIFs are inefficient for delivering animated content. Consider using MPEG4/WebM videos for animations and PNG/WebP for static images instead of GIF to save network bytes. [Learn more](https://web.dev/efficient-animated-content)",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "appcache-manifest": {
+      "id": "appcache-manifest",
+      "title": "Avoids Application Cache",
+      "description": "Application Cache is deprecated. [Learn more](https://web.dev/appcache-manifest).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required AppCacheManifest gatherer did not run."
+    },
+    "doctype": {
+      "id": "doctype",
+      "title": "Page has the HTML doctype",
+      "description": "Specifying a doctype prevents the browser from switching to quirks-mode. [Learn more](https://web.dev/doctype).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required Doctype gatherer did not run."
+    },
+    "dom-size": {
+      "id": "dom-size",
+      "title": "Avoids an excessive DOM size",
+      "description": "A large DOM will increase memory usage, cause longer [style calculations](https://developers.google.com/web/fundamentals/performance/rendering/reduce-the-scope-and-complexity-of-style-calculations), and produce costly [layout reflows](https://developers.google.com/speed/articles/reflow). [Learn more](https://web.dev/dom-size).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required DOMStats gatherer did not run."
+    },
+    "external-anchors-use-rel-noopener": {
+      "id": "external-anchors-use-rel-noopener",
+      "title": "Links to cross-origin destinations are safe",
+      "description": "Add `rel=\"noopener\"` or `rel=\"noreferrer\"` to any external links to improve performance and prevent security vulnerabilities. [Learn more](https://web.dev/external-anchors-use-rel-noopener).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required AnchorElements gatherer did not run."
+    },
+    "geolocation-on-start": {
+      "id": "geolocation-on-start",
+      "title": "Avoids requesting the geolocation permission on page load",
+      "description": "Users are mistrustful of or confused by sites that request their location without context. Consider tying the request to a user action instead. [Learn more](https://web.dev/geolocation-on-start).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ConsoleMessages gatherer did not run."
+    },
+    "no-document-write": {
+      "id": "no-document-write",
+      "title": "Avoids `document.write()`",
+      "description": "For users on slow connections, external scripts dynamically injected via `document.write()` can delay page load by tens of seconds. [Learn more](https://web.dev/no-document-write).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ConsoleMessages gatherer did not run."
+    },
+    "no-vulnerable-libraries": {
+      "id": "no-vulnerable-libraries",
+      "title": "Avoids front-end JavaScript libraries with known security vulnerabilities",
+      "description": "Some third-party scripts may contain known security vulnerabilities that are easily identified and exploited by attackers. [Learn more](https://web.dev/no-vulnerable-libraries).",
+      "score": 1,
+      "scoreDisplayMode": "binary"
+    },
+    "js-libraries": {
+      "id": "js-libraries",
+      "title": "Detected JavaScript libraries",
+      "description": "All front-end JavaScript libraries detected on the page. [Learn more](https://web.dev/js-libraries).",
+      "score": 1,
+      "scoreDisplayMode": "binary",
+      "details": {
+        "type": "table",
+        "headings": [],
+        "items": [],
+        "summary": {}
+      }
+    },
+    "notification-on-start": {
+      "id": "notification-on-start",
+      "title": "Avoids requesting the notification permission on page load",
+      "description": "Users are mistrustful of or confused by sites that request to send notifications without context. Consider tying the request to user gestures instead. [Learn more](https://web.dev/notification-on-start).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ConsoleMessages gatherer did not run."
+    },
+    "password-inputs-can-be-pasted-into": {
+      "id": "password-inputs-can-be-pasted-into",
+      "title": "Allows users to paste into password fields",
+      "description": "Preventing password pasting undermines good security policy. [Learn more](https://web.dev/password-inputs-can-be-pasted-into).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required PasswordInputsWithPreventedPaste gatherer did not run."
+    },
+    "uses-http2": {
+      "id": "uses-http2",
+      "title": "Uses HTTP/2 for its own resources",
+      "description": "HTTP/2 offers many benefits over HTTP/1.1, including binary headers, multiplexing, and server push. [Learn more](https://web.dev/uses-http2).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "uses-passive-event-listeners": {
+      "id": "uses-passive-event-listeners",
+      "title": "Uses passive listeners to improve scrolling performance",
+      "description": "Consider marking your touch and wheel event listeners as `passive` to improve your page's scroll performance. [Learn more](https://web.dev/uses-passive-event-listeners).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required ConsoleMessages gatherer did not run."
+    },
+    "meta-description": {
+      "id": "meta-description",
+      "title": "Document has a meta description",
+      "description": "Meta descriptions may be included in search results to concisely summarize page content. [Learn more](https://web.dev/meta-description).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required MetaElements gatherer did not run."
+    },
+    "http-status-code": {
+      "id": "http-status-code",
+      "title": "Page has successful HTTP status code",
+      "description": "Pages with unsuccessful HTTP status codes may not be indexed properly. [Learn more](https://web.dev/http-status-code).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required devtoolsLogs gatherer did not run."
+    },
+    "font-size": {
+      "id": "font-size",
+      "title": "Document uses legible font sizes",
+      "description": "Font sizes less than 12px are too small to be legible and require mobile visitors to “pinch to zoom” in order to read. Strive to have >60% of page text ≥12px. [Learn more](https://web.dev/font-size).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required FontSize gatherer did not run."
+    },
+    "link-text": {
+      "id": "link-text",
+      "title": "Links have descriptive text",
+      "description": "Descriptive link text helps search engines understand your content. [Learn more](https://web.dev/link-text).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required AnchorElements gatherer did not run."
+    },
+    "is-crawlable": {
+      "id": "is-crawlable",
+      "title": "Page isn’t blocked from indexing",
+      "description": "Search engines are unable to include your pages in search results if they don't have permission to crawl them. [Learn more](https://web.dev/is-crawable).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required MetaElements gatherer did not run."
+    },
+    "robots-txt": {
+      "id": "robots-txt",
+      "title": "robots.txt is valid",
+      "description": "If your robots.txt file is malformed, crawlers may not be able to understand how you want your website to be crawled or indexed. [Learn more](https://web.dev/robots-txt).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required RobotsTxt gatherer did not run."
+    },
+    "tap-targets": {
+      "id": "tap-targets",
+      "title": "Tap targets are sized appropriately",
+      "description": "Interactive elements like buttons and links should be large enough (48x48px), and have enough space around them, to be easy enough to tap without overlapping onto other elements. [Learn more](https://web.dev/tap-targets).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required MetaElements gatherer did not run."
+    },
+    "hreflang": {
+      "id": "hreflang",
+      "title": "Document has a valid `hreflang`",
+      "description": "hreflang links tell search engines what version of a page they should list in search results for a given language or region. [Learn more](https://web.dev/hreflang).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required LinkElements gatherer did not run."
+    },
+    "plugins": {
+      "id": "plugins",
+      "title": "Document avoids plugins",
+      "description": "Search engines can't index plugin content, and many devices restrict plugins or don't support them. [Learn more](https://web.dev/plugins).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required EmbeddedContent gatherer did not run."
+    },
+    "canonical": {
+      "id": "canonical",
+      "title": "Document has a valid `rel=canonical`",
+      "description": "Canonical links suggest which URL to show in search results. [Learn more](https://web.dev/canonical).",
+      "score": null,
+      "scoreDisplayMode": "error",
+      "errorMessage": "Required LinkElements gatherer did not run."
+    },
+    "structured-data": {
+      "id": "structured-data",
+      "title": "Structured data is valid",
+      "description": "Run the [Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/) and the [Structured Data Linter](http://linter.structured-data.org/) to validate structured data. [Learn more](https://web.dev/structured-data).",
+      "score": null,
+      "scoreDisplayMode": "manual"
+    }
+  },
+  "configSettings": {
+    "output": "html",
+    "maxWaitForFcp": 30000,
+    "maxWaitForLoad": 45000,
+    "throttlingMethod": "simulate",
+    "throttling": {
+      "rttMs": 150,
+      "throughputKbps": 1638.4,
+      "requestLatencyMs": 562.5,
+      "downloadThroughputKbps": 1474.5600000000002,
+      "uploadThroughputKbps": 675,
+      "cpuSlowdownMultiplier": 4
+    },
+    "auditMode": false,
+    "gatherMode": false,
+    "disableStorageReset": false,
+    "emulatedFormFactor": "mobile",
+    "channel": "node",
+    "budgets": null,
+    "locale": "en-US",
+    "blockedUrlPatterns": null,
+    "additionalTraceCategories": null,
+    "extraHeaders": null,
+    "precomputedLanternData": null,
+    "onlyAudits": null,
+    "onlyCategories": null,
+    "skipAudits": null
+  },
+  "categories": {
+    "performance": {
+      "title": "Performance",
+      "auditRefs": [
+        {
+          "id": "first-contentful-paint",
+          "weight": 3,
+          "group": "metrics"
+        },
+        {
+          "id": "first-meaningful-paint",
+          "weight": 1,
+          "group": "metrics"
+        },
+        {
+          "id": "speed-index",
+          "weight": 4,
+          "group": "metrics"
+        },
+        {
+          "id": "interactive",
+          "weight": 5,
+          "group": "metrics"
+        },
+        {
+          "id": "first-cpu-idle",
+          "weight": 2,
+          "group": "metrics"
+        },
+        {
+          "id": "max-potential-fid",
+          "weight": 0,
+          "group": "metrics"
+        },
+        {
+          "id": "estimated-input-latency",
+          "weight": 0
+        },
+        {
+          "id": "total-blocking-time",
+          "weight": 0
+        },
+        {
+          "id": "render-blocking-resources",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "uses-responsive-images",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "offscreen-images",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "unminified-css",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "unminified-javascript",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "unused-css-rules",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "uses-optimized-images",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "uses-webp-images",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "uses-text-compression",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "uses-rel-preconnect",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "time-to-first-byte",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "redirects",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "uses-rel-preload",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "efficient-animated-content",
+          "weight": 0,
+          "group": "load-opportunities"
+        },
+        {
+          "id": "total-byte-weight",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
+          "id": "uses-long-cache-ttl",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
+          "id": "dom-size",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
+          "id": "critical-request-chains",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
+          "id": "user-timings",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
+          "id": "bootup-time",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
+          "id": "mainthread-work-breakdown",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
+          "id": "font-display",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
+          "id": "performance-budget",
+          "weight": 0,
+          "group": "budgets"
+        },
+        {
+          "id": "resource-summary",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
+          "id": "third-party-summary",
+          "weight": 0,
+          "group": "diagnostics"
+        },
+        {
+          "id": "network-requests",
+          "weight": 0
+        },
+        {
+          "id": "network-rtt",
+          "weight": 0
+        },
+        {
+          "id": "network-server-latency",
+          "weight": 0
+        },
+        {
+          "id": "main-thread-tasks",
+          "weight": 0
+        },
+        {
+          "id": "diagnostics",
+          "weight": 0
+        },
+        {
+          "id": "metrics",
+          "weight": 0
+        },
+        {
+          "id": "screenshot-thumbnails",
+          "weight": 0
+        },
+        {
+          "id": "final-screenshot",
+          "weight": 0
+        }
+      ],
+      "id": "performance",
+      "score": null
+    },
+    "accessibility": {
+      "title": "Accessibility",
+      "description": "These checks highlight opportunities to [improve the accessibility of your web app](https://developers.google.com/web/fundamentals/accessibility). Only a subset of accessibility issues can be automatically detected so manual testing is also encouraged.",
+      "manualDescription": "These items address areas which an automated testing tool cannot cover. Learn more in our guide on [conducting an accessibility review](https://developers.google.com/web/fundamentals/accessibility/how-to-review).",
+      "auditRefs": [
+        {
+          "id": "accesskeys",
+          "weight": 3,
+          "group": "a11y-navigation"
+        },
+        {
+          "id": "aria-allowed-attr",
+          "weight": 10,
+          "group": "a11y-aria"
+        },
+        {
+          "id": "aria-required-attr",
+          "weight": 10,
+          "group": "a11y-aria"
+        },
+        {
+          "id": "aria-required-children",
+          "weight": 10,
+          "group": "a11y-aria"
+        },
+        {
+          "id": "aria-required-parent",
+          "weight": 10,
+          "group": "a11y-aria"
+        },
+        {
+          "id": "aria-roles",
+          "weight": 10,
+          "group": "a11y-aria"
+        },
+        {
+          "id": "aria-valid-attr-value",
+          "weight": 10,
+          "group": "a11y-aria"
+        },
+        {
+          "id": "aria-valid-attr",
+          "weight": 10,
+          "group": "a11y-aria"
+        },
+        {
+          "id": "audio-caption",
+          "weight": 10,
+          "group": "a11y-audio-video"
+        },
+        {
+          "id": "button-name",
+          "weight": 10,
+          "group": "a11y-names-labels"
+        },
+        {
+          "id": "bypass",
+          "weight": 3,
+          "group": "a11y-navigation"
+        },
+        {
+          "id": "color-contrast",
+          "weight": 3,
+          "group": "a11y-color-contrast"
+        },
+        {
+          "id": "definition-list",
+          "weight": 3,
+          "group": "a11y-tables-lists"
+        },
+        {
+          "id": "dlitem",
+          "weight": 3,
+          "group": "a11y-tables-lists"
+        },
+        {
+          "id": "document-title",
+          "weight": 3,
+          "group": "a11y-names-labels"
+        },
+        {
+          "id": "duplicate-id",
+          "weight": 1,
+          "group": "a11y-best-practices"
+        },
+        {
+          "id": "frame-title",
+          "weight": 3,
+          "group": "a11y-names-labels"
+        },
+        {
+          "id": "html-has-lang",
+          "weight": 3,
+          "group": "a11y-language"
+        },
+        {
+          "id": "html-lang-valid",
+          "weight": 3,
+          "group": "a11y-language"
+        },
+        {
+          "id": "image-alt",
+          "weight": 10,
+          "group": "a11y-names-labels"
+        },
+        {
+          "id": "input-image-alt",
+          "weight": 10,
+          "group": "a11y-names-labels"
+        },
+        {
+          "id": "label",
+          "weight": 10,
+          "group": "a11y-names-labels"
+        },
+        {
+          "id": "layout-table",
+          "weight": 3,
+          "group": "a11y-tables-lists"
+        },
+        {
+          "id": "link-name",
+          "weight": 3,
+          "group": "a11y-names-labels"
+        },
+        {
+          "id": "list",
+          "weight": 3,
+          "group": "a11y-tables-lists"
+        },
+        {
+          "id": "listitem",
+          "weight": 3,
+          "group": "a11y-tables-lists"
+        },
+        {
+          "id": "meta-refresh",
+          "weight": 10,
+          "group": "a11y-best-practices"
+        },
+        {
+          "id": "meta-viewport",
+          "weight": 10,
+          "group": "a11y-best-practices"
+        },
+        {
+          "id": "object-alt",
+          "weight": 3,
+          "group": "a11y-names-labels"
+        },
+        {
+          "id": "tabindex",
+          "weight": 3,
+          "group": "a11y-navigation"
+        },
+        {
+          "id": "td-headers-attr",
+          "weight": 3,
+          "group": "a11y-tables-lists"
+        },
+        {
+          "id": "th-has-data-cells",
+          "weight": 3,
+          "group": "a11y-tables-lists"
+        },
+        {
+          "id": "valid-lang",
+          "weight": 3,
+          "group": "a11y-language"
+        },
+        {
+          "id": "video-caption",
+          "weight": 10,
+          "group": "a11y-audio-video"
+        },
+        {
+          "id": "video-description",
+          "weight": 10,
+          "group": "a11y-audio-video"
+        },
+        {
+          "id": "logical-tab-order",
+          "weight": 0
+        },
+        {
+          "id": "focusable-controls",
+          "weight": 0
+        },
+        {
+          "id": "interactive-element-affordance",
+          "weight": 0
+        },
+        {
+          "id": "managed-focus",
+          "weight": 0
+        },
+        {
+          "id": "focus-traps",
+          "weight": 0
+        },
+        {
+          "id": "custom-controls-labels",
+          "weight": 0
+        },
+        {
+          "id": "custom-controls-roles",
+          "weight": 0
+        },
+        {
+          "id": "visual-order-follows-dom",
+          "weight": 0
+        },
+        {
+          "id": "offscreen-content-hidden",
+          "weight": 0
+        },
+        {
+          "id": "heading-levels",
+          "weight": 0
+        },
+        {
+          "id": "use-landmarks",
+          "weight": 0
+        }
+      ],
+      "id": "accessibility",
+      "score": null
+    },
+    "best-practices": {
+      "title": "Best Practices",
+      "auditRefs": [
+        {
+          "id": "appcache-manifest",
+          "weight": 1
+        },
+        {
+          "id": "is-on-https",
+          "weight": 1
+        },
+        {
+          "id": "uses-http2",
+          "weight": 1
+        },
+        {
+          "id": "uses-passive-event-listeners",
+          "weight": 1
+        },
+        {
+          "id": "no-document-write",
+          "weight": 1
+        },
+        {
+          "id": "external-anchors-use-rel-noopener",
+          "weight": 1
+        },
+        {
+          "id": "geolocation-on-start",
+          "weight": 1
+        },
+        {
+          "id": "doctype",
+          "weight": 1
+        },
+        {
+          "id": "no-vulnerable-libraries",
+          "weight": 1
+        },
+        {
+          "id": "js-libraries",
+          "weight": 0
+        },
+        {
+          "id": "notification-on-start",
+          "weight": 1
+        },
+        {
+          "id": "deprecations",
+          "weight": 1
+        },
+        {
+          "id": "password-inputs-can-be-pasted-into",
+          "weight": 1
+        },
+        {
+          "id": "errors-in-console",
+          "weight": 1
+        },
+        {
+          "id": "image-aspect-ratio",
+          "weight": 1
+        }
+      ],
+      "id": "best-practices",
+      "score": null
+    },
+    "seo": {
+      "title": "SEO",
+      "description": "These checks ensure that your page is optimized for search engine results ranking. There are additional factors Lighthouse does not check that may affect your search ranking. [Learn more](https://support.google.com/webmasters/answer/35769).",
+      "manualDescription": "Run these additional validators on your site to check additional SEO best practices.",
+      "auditRefs": [
+        {
+          "id": "viewport",
+          "weight": 1,
+          "group": "seo-mobile"
+        },
+        {
+          "id": "document-title",
+          "weight": 1,
+          "group": "seo-content"
+        },
+        {
+          "id": "meta-description",
+          "weight": 1,
+          "group": "seo-content"
+        },
+        {
+          "id": "http-status-code",
+          "weight": 1,
+          "group": "seo-crawl"
+        },
+        {
+          "id": "link-text",
+          "weight": 1,
+          "group": "seo-content"
+        },
+        {
+          "id": "is-crawlable",
+          "weight": 1,
+          "group": "seo-crawl"
+        },
+        {
+          "id": "robots-txt",
+          "weight": 1,
+          "group": "seo-crawl"
+        },
+        {
+          "id": "image-alt",
+          "weight": 1,
+          "group": "seo-content"
+        },
+        {
+          "id": "hreflang",
+          "weight": 1,
+          "group": "seo-content"
+        },
+        {
+          "id": "canonical",
+          "weight": 1,
+          "group": "seo-content"
+        },
+        {
+          "id": "font-size",
+          "weight": 1,
+          "group": "seo-mobile"
+        },
+        {
+          "id": "plugins",
+          "weight": 1,
+          "group": "seo-content"
+        },
+        {
+          "id": "tap-targets",
+          "weight": 1,
+          "group": "seo-mobile"
+        },
+        {
+          "id": "structured-data",
+          "weight": 0
+        }
+      ],
+      "id": "seo",
+      "score": null
+    },
+    "pwa": {
+      "title": "Progressive Web App",
+      "description": "These checks validate the aspects of a Progressive Web App. [Learn more](https://developers.google.com/web/progressive-web-apps/checklist).",
+      "manualDescription": "These checks are required by the baseline [PWA Checklist](https://developers.google.com/web/progressive-web-apps/checklist) but are not automatically checked by Lighthouse. They do not affect your score but it's important that you verify them manually.",
+      "auditRefs": [
+        {
+          "id": "load-fast-enough-for-pwa",
+          "weight": 7,
+          "group": "pwa-fast-reliable"
+        },
+        {
+          "id": "works-offline",
+          "weight": 5,
+          "group": "pwa-fast-reliable"
+        },
+        {
+          "id": "offline-start-url",
+          "weight": 1,
+          "group": "pwa-fast-reliable"
+        },
+        {
+          "id": "is-on-https",
+          "weight": 2,
+          "group": "pwa-installable"
+        },
+        {
+          "id": "service-worker",
+          "weight": 1,
+          "group": "pwa-installable"
+        },
+        {
+          "id": "installable-manifest",
+          "weight": 2,
+          "group": "pwa-installable"
+        },
+        {
+          "id": "redirects-http",
+          "weight": 2,
+          "group": "pwa-optimized"
+        },
+        {
+          "id": "splash-screen",
+          "weight": 1,
+          "group": "pwa-optimized"
+        },
+        {
+          "id": "themed-omnibox",
+          "weight": 1,
+          "group": "pwa-optimized"
+        },
+        {
+          "id": "content-width",
+          "weight": 1,
+          "group": "pwa-optimized"
+        },
+        {
+          "id": "viewport",
+          "weight": 2,
+          "group": "pwa-optimized"
+        },
+        {
+          "id": "without-javascript",
+          "weight": 1,
+          "group": "pwa-optimized"
+        },
+        {
+          "id": "apple-touch-icon",
+          "weight": 1,
+          "group": "pwa-optimized"
+        },
+        {
+          "id": "pwa-cross-browser",
+          "weight": 0
+        },
+        {
+          "id": "pwa-page-transitions",
+          "weight": 0
+        },
+        {
+          "id": "pwa-each-page-has-url",
+          "weight": 0
+        }
+      ],
+      "id": "pwa",
+      "score": null
+    }
+  },
+  "categoryGroups": {
+    "metrics": {
+      "title": "Metrics"
+    },
+    "load-opportunities": {
+      "title": "Opportunities",
+      "description": "These suggestions can help your page load faster. They don't [directly affect](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) the Performance score."
+    },
+    "budgets": {
+      "title": "Budgets",
+      "description": "Performance budgets set standards for the performance of your site."
+    },
+    "diagnostics": {
+      "title": "Diagnostics",
+      "description": "More information about the performance of your application. These numbers don't [directly affect](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted) the Performance score."
+    },
+    "pwa-fast-reliable": {
+      "title": "Fast and reliable"
+    },
+    "pwa-installable": {
+      "title": "Installable"
+    },
+    "pwa-optimized": {
+      "title": "PWA Optimized"
+    },
+    "a11y-best-practices": {
+      "title": "Best practices",
+      "description": "These items highlight common accessibility best practices."
+    },
+    "a11y-color-contrast": {
+      "title": "Contrast",
+      "description": "These are opportunities to improve the legibility of your content."
+    },
+    "a11y-names-labels": {
+      "title": "Names and labels",
+      "description": "These are opportunities to improve the semantics of the controls in your application. This may enhance the experience for users of assistive technology, like a screen reader."
+    },
+    "a11y-navigation": {
+      "title": "Navigation",
+      "description": "These are opportunities to improve keyboard navigation in your application."
+    },
+    "a11y-aria": {
+      "title": "ARIA",
+      "description": "These are opportunities to improve the usage of ARIA in your application which may enhance the experience for users of assistive technology, like a screen reader."
+    },
+    "a11y-language": {
+      "title": "Internationalization and localization",
+      "description": "These are opportunities to improve the interpretation of your content by users in different locales."
+    },
+    "a11y-audio-video": {
+      "title": "Audio and video",
+      "description": "These are opportunities to provide alternative content for audio and video. This may improve the experience for users with hearing or vision impairments."
+    },
+    "a11y-tables-lists": {
+      "title": "Tables and lists",
+      "description": "These are opportunities to to improve the experience of reading tabular or list data using assistive technology, like a screen reader."
+    },
+    "seo-mobile": {
+      "title": "Mobile Friendly",
+      "description": "Make sure your pages are mobile friendly so users don’t have to pinch or zoom in order to read the content pages. [Learn more](https://developers.google.com/search/mobile-sites/)."
+    },
+    "seo-content": {
+      "title": "Content Best Practices",
+      "description": "Format your HTML in a way that enables crawlers to better understand your app’s content."
+    },
+    "seo-crawl": {
+      "title": "Crawling and Indexing",
+      "description": "To appear in search results, crawlers need access to your app."
+    }
+  },
+  "timing": {
+    "entries": [
+      {
+        "startTime": 4716.42,
+        "name": "lh:init:config",
+        "duration": 2381.99,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 4720.63,
+        "name": "lh:config:requireGatherers",
+        "duration": 413.59,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 5134.71,
+        "name": "lh:config:requireAudits",
+        "duration": 1933.3,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 7099.87,
+        "name": "lh:runner:run",
+        "duration": 31547.62,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 7105.71,
+        "name": "lh:init:connect",
+        "duration": 235.6,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 7341.94,
+        "name": "lh:gather:loadBlank",
+        "duration": 53.93,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 7396.17,
+        "name": "lh:gather:getVersion",
+        "duration": 5.09,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 7404.76,
+        "name": "lh:gather:getBenchmarkIndex",
+        "duration": 515.94,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 7920.9,
+        "name": "lh:gather:setupDriver",
+        "duration": 76.27,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 7997.72,
+        "name": "lh:gather:loadBlank",
+        "duration": 75.29,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8073.3,
+        "name": "lh:gather:setupPassNetwork",
+        "duration": 10.41,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8083.99,
+        "name": "lh:driver:cleanBrowserCaches",
+        "duration": 23.98,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8108.33,
+        "name": "lh:gather:beforePass",
+        "duration": 10.74,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8108.41,
+        "name": "lh:gather:beforePass:CSSUsage",
+        "duration": 0.4,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8108.99,
+        "name": "lh:gather:beforePass:ViewportDimensions",
+        "duration": 0.09,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8109.12,
+        "name": "lh:gather:beforePass:RuntimeExceptions",
+        "duration": 0.24,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8109.56,
+        "name": "lh:gather:beforePass:ConsoleMessages",
+        "duration": 5.45,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8115.08,
+        "name": "lh:gather:beforePass:AnchorElements",
+        "duration": 0.05,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8115.17,
+        "name": "lh:gather:beforePass:ImageElements",
+        "duration": 0.04,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8115.23,
+        "name": "lh:gather:beforePass:LinkElements",
+        "duration": 0.04,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8115.3,
+        "name": "lh:gather:beforePass:MetaElements",
+        "duration": 0.04,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8115.38,
+        "name": "lh:gather:beforePass:ScriptElements",
+        "duration": 0.03,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8115.58,
+        "name": "lh:gather:beforePass:IFrameElements",
+        "duration": 0.07,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8115.71,
+        "name": "lh:gather:beforePass:MainDocumentContent",
+        "duration": 0.04,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8115.77,
+        "name": "lh:gather:beforePass:AppCacheManifest",
+        "duration": 0.03,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8115.83,
+        "name": "lh:gather:beforePass:Doctype",
+        "duration": 0.03,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8115.89,
+        "name": "lh:gather:beforePass:DOMStats",
+        "duration": 0.03,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8115.95,
+        "name": "lh:gather:beforePass:OptimizedImages",
+        "duration": 0.03,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8116.01,
+        "name": "lh:gather:beforePass:PasswordInputsWithPreventedPaste",
+        "duration": 0.03,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8116.06,
+        "name": "lh:gather:beforePass:ResponseCompression",
+        "duration": 0.03,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8116.11,
+        "name": "lh:gather:beforePass:TagsBlockingFirstPaint",
+        "duration": 2.45,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8118.74,
+        "name": "lh:gather:beforePass:FontSize",
+        "duration": 0.06,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8118.83,
+        "name": "lh:gather:beforePass:EmbeddedContent",
+        "duration": 0.06,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8118.92,
+        "name": "lh:gather:beforePass:RobotsTxt",
+        "duration": 0.03,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8118.97,
+        "name": "lh:gather:beforePass:TapTargets",
+        "duration": 0.03,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8119.02,
+        "name": "lh:gather:beforePass:Accessibility",
+        "duration": 0.03,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8119.26,
+        "name": "lh:gather:beginRecording",
+        "duration": 21.05,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8123.62,
+        "name": "lh:gather:getVersion",
+        "duration": 2.57,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 8141.6,
+        "name": "lh:gather:loadPage-defaultPass",
+        "duration": 30027.94,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38169.9,
+        "name": "lh:gather:pass",
+        "duration": 6.3,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38176.74,
+        "name": "lh:gather:getTrace",
+        "duration": 61.67,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38238.44,
+        "name": "lh:gather:getDevtoolsLog",
+        "duration": 1.74,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38260.33,
+        "name": "lh:gather:disconnect",
+        "duration": 18.44,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38279.44,
+        "name": "lh:runner:auditing",
+        "duration": 356.75,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38298.8,
+        "name": "lh:audit:is-on-https",
+        "duration": 5.32,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38304.71,
+        "name": "lh:audit:redirects-http",
+        "duration": 1.05,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38306.68,
+        "name": "lh:audit:service-worker",
+        "duration": 3.01,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38310.71,
+        "name": "lh:audit:works-offline",
+        "duration": 3.36,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38314.65,
+        "name": "lh:audit:viewport",
+        "duration": 2.82,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38318.45,
+        "name": "lh:audit:without-javascript",
+        "duration": 3.48,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38322.37,
+        "name": "lh:audit:first-contentful-paint",
+        "duration": 1.81,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38324.92,
+        "name": "lh:audit:first-meaningful-paint",
+        "duration": 0.91,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38326.79,
+        "name": "lh:audit:load-fast-enough-for-pwa",
+        "duration": 1.08,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38329.13,
+        "name": "lh:audit:speed-index",
+        "duration": 1.41,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38330.64,
+        "name": "lh:audit:screenshot-thumbnails",
+        "duration": 0.91,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38331.6,
+        "name": "lh:audit:final-screenshot",
+        "duration": 0.55,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38333,
+        "name": "lh:audit:estimated-input-latency",
+        "duration": 1.1,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38334.72,
+        "name": "lh:audit:total-blocking-time",
+        "duration": 0.93,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38336.46,
+        "name": "lh:audit:max-potential-fid",
+        "duration": 1.25,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38338.38,
+        "name": "lh:audit:errors-in-console",
+        "duration": 1.45,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38340.5,
+        "name": "lh:audit:time-to-first-byte",
+        "duration": 1.01,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38342.05,
+        "name": "lh:audit:first-cpu-idle",
+        "duration": 2.34,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38344.83,
+        "name": "lh:audit:interactive",
+        "duration": 1.32,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38346.68,
+        "name": "lh:audit:user-timings",
+        "duration": 0.66,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38351.69,
+        "name": "lh:audit:critical-request-chains",
+        "duration": 0.94,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38354.17,
+        "name": "lh:audit:redirects",
+        "duration": 1.58,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38356.23,
+        "name": "lh:audit:installable-manifest",
+        "duration": 5.31,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38359.81,
+        "name": "lh:computed:ManifestValues",
+        "duration": 0.49,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38361.99,
+        "name": "lh:audit:apple-touch-icon",
+        "duration": 4.96,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38367.61,
+        "name": "lh:audit:splash-screen",
+        "duration": 1.11,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38369.65,
+        "name": "lh:audit:themed-omnibox",
+        "duration": 1.77,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38372.54,
+        "name": "lh:audit:content-width",
+        "duration": 1.15,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38375.22,
+        "name": "lh:audit:image-aspect-ratio",
+        "duration": 3.29,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38379.19,
+        "name": "lh:audit:deprecations",
+        "duration": 1.49,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38381.47,
+        "name": "lh:audit:mainthread-work-breakdown",
+        "duration": 1.05,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38383.19,
+        "name": "lh:audit:bootup-time",
+        "duration": 1.36,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38384.96,
+        "name": "lh:audit:uses-rel-preload",
+        "duration": 0.79,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38386.44,
+        "name": "lh:audit:uses-rel-preconnect",
+        "duration": 1.14,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38388.74,
+        "name": "lh:audit:font-display",
+        "duration": 0.88,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38389.68,
+        "name": "lh:audit:diagnostics",
+        "duration": 1.48,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38391.47,
+        "name": "lh:audit:network-requests",
+        "duration": 0.51,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38392.31,
+        "name": "lh:audit:network-rtt",
+        "duration": 0.75,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38393.48,
+        "name": "lh:audit:network-server-latency",
+        "duration": 1.68,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38395.22,
+        "name": "lh:audit:main-thread-tasks",
+        "duration": 0.77,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38396.04,
+        "name": "lh:audit:metrics",
+        "duration": 0.87,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38397.86,
+        "name": "lh:audit:offline-start-url",
+        "duration": 1.92,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38400.1,
+        "name": "lh:audit:performance-budget",
+        "duration": 2.46,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38402.99,
+        "name": "lh:audit:resource-summary",
+        "duration": 0.84,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38404.26,
+        "name": "lh:audit:third-party-summary",
+        "duration": 5.46,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38410.13,
+        "name": "lh:audit:pwa-cross-browser",
+        "duration": 0.68,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38411.58,
+        "name": "lh:audit:pwa-page-transitions",
+        "duration": 0.3,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38412.09,
+        "name": "lh:audit:pwa-each-page-has-url",
+        "duration": 0.57,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38413.24,
+        "name": "lh:audit:accesskeys",
+        "duration": 1.55,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38415.19,
+        "name": "lh:audit:aria-allowed-attr",
+        "duration": 4.26,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38419.86,
+        "name": "lh:audit:aria-required-attr",
+        "duration": 1.69,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38422.19,
+        "name": "lh:audit:aria-required-children",
+        "duration": 1.14,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38426.24,
+        "name": "lh:audit:aria-required-parent",
+        "duration": 1.58,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38428.69,
+        "name": "lh:audit:aria-roles",
+        "duration": 2.05,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38431.14,
+        "name": "lh:audit:aria-valid-attr-value",
+        "duration": 1.27,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38433.15,
+        "name": "lh:audit:aria-valid-attr",
+        "duration": 1.95,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38435.7,
+        "name": "lh:audit:audio-caption",
+        "duration": 1.87,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38437.92,
+        "name": "lh:audit:button-name",
+        "duration": 1.96,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38440.35,
+        "name": "lh:audit:bypass",
+        "duration": 1.34,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38442.53,
+        "name": "lh:audit:color-contrast",
+        "duration": 1.35,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38446.02,
+        "name": "lh:audit:definition-list",
+        "duration": 1.51,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38448.01,
+        "name": "lh:audit:dlitem",
+        "duration": 1.18,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38450,
+        "name": "lh:audit:document-title",
+        "duration": 1.07,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38451.59,
+        "name": "lh:audit:duplicate-id",
+        "duration": 1.27,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38453.71,
+        "name": "lh:audit:frame-title",
+        "duration": 1.28,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38456.18,
+        "name": "lh:audit:html-has-lang",
+        "duration": 1.06,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38457.95,
+        "name": "lh:audit:html-lang-valid",
+        "duration": 1.5,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38459.84,
+        "name": "lh:audit:image-alt",
+        "duration": 1.15,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38462.58,
+        "name": "lh:audit:input-image-alt",
+        "duration": 4.79,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38467.95,
+        "name": "lh:audit:label",
+        "duration": 1.63,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38470.24,
+        "name": "lh:audit:layout-table",
+        "duration": 2.92,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38475.53,
+        "name": "lh:audit:link-name",
+        "duration": 2.79,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38479.2,
+        "name": "lh:audit:list",
+        "duration": 3.36,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38483.19,
+        "name": "lh:audit:listitem",
+        "duration": 2.68,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38486.38,
+        "name": "lh:audit:meta-refresh",
+        "duration": 3.54,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38491.06,
+        "name": "lh:audit:meta-viewport",
+        "duration": 4.24,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38495.92,
+        "name": "lh:audit:object-alt",
+        "duration": 4.45,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38500.89,
+        "name": "lh:audit:tabindex",
+        "duration": 2.06,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38503.92,
+        "name": "lh:audit:td-headers-attr",
+        "duration": 3.09,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38508.03,
+        "name": "lh:audit:th-has-data-cells",
+        "duration": 2.53,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38510.98,
+        "name": "lh:audit:valid-lang",
+        "duration": 1.09,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38512.96,
+        "name": "lh:audit:video-caption",
+        "duration": 1.47,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38515,
+        "name": "lh:audit:video-description",
+        "duration": 1.45,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38516.56,
+        "name": "lh:audit:custom-controls-labels",
+        "duration": 0.23,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38516.85,
+        "name": "lh:audit:custom-controls-roles",
+        "duration": 0.37,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38517.38,
+        "name": "lh:audit:focus-traps",
+        "duration": 0.27,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38517.75,
+        "name": "lh:audit:focusable-controls",
+        "duration": 0.2,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38519.38,
+        "name": "lh:audit:heading-levels",
+        "duration": 0.24,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38519.66,
+        "name": "lh:audit:interactive-element-affordance",
+        "duration": 0.14,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38519.84,
+        "name": "lh:audit:logical-tab-order",
+        "duration": 0.14,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38520.01,
+        "name": "lh:audit:managed-focus",
+        "duration": 0.13,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38520.19,
+        "name": "lh:audit:offscreen-content-hidden",
+        "duration": 0.13,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38520.35,
+        "name": "lh:audit:use-landmarks",
+        "duration": 2.42,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38522.82,
+        "name": "lh:audit:visual-order-follows-dom",
+        "duration": 1.38,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38525.21,
+        "name": "lh:audit:uses-long-cache-ttl",
+        "duration": 1.31,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38534.41,
+        "name": "lh:audit:total-byte-weight",
+        "duration": 0.75,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38535.69,
+        "name": "lh:audit:offscreen-images",
+        "duration": 0.9,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38537.03,
+        "name": "lh:audit:render-blocking-resources",
+        "duration": 0.87,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38538.21,
+        "name": "lh:audit:unminified-css",
+        "duration": 5.09,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38543.75,
+        "name": "lh:audit:unminified-javascript",
+        "duration": 2.98,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38547.07,
+        "name": "lh:audit:unused-css-rules",
+        "duration": 5.23,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38552.92,
+        "name": "lh:audit:uses-webp-images",
+        "duration": 3.32,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38556.96,
+        "name": "lh:audit:uses-optimized-images",
+        "duration": 2.44,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38559.73,
+        "name": "lh:audit:uses-text-compression",
+        "duration": 1.66,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38563.24,
+        "name": "lh:audit:uses-responsive-images",
+        "duration": 3.36,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38566.9,
+        "name": "lh:audit:efficient-animated-content",
+        "duration": 2.66,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38569.92,
+        "name": "lh:audit:appcache-manifest",
+        "duration": 2.55,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38572.88,
+        "name": "lh:audit:doctype",
+        "duration": 2.9,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38576.18,
+        "name": "lh:audit:dom-size",
+        "duration": 3.58,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38580.19,
+        "name": "lh:audit:external-anchors-use-rel-noopener",
+        "duration": 3.95,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38584.74,
+        "name": "lh:audit:geolocation-on-start",
+        "duration": 1.91,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38587.03,
+        "name": "lh:audit:no-document-write",
+        "duration": 4.23,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38592.53,
+        "name": "lh:audit:no-vulnerable-libraries",
+        "duration": 3.51,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38596.55,
+        "name": "lh:audit:js-libraries",
+        "duration": 1.73,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38598.87,
+        "name": "lh:audit:notification-on-start",
+        "duration": 3.62,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38602.98,
+        "name": "lh:audit:password-inputs-can-be-pasted-into",
+        "duration": 6.31,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38609.73,
+        "name": "lh:audit:uses-http2",
+        "duration": 2.14,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38612.21,
+        "name": "lh:audit:uses-passive-event-listeners",
+        "duration": 1.37,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38614.8,
+        "name": "lh:audit:meta-description",
+        "duration": 1.91,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38617.34,
+        "name": "lh:audit:http-status-code",
+        "duration": 1.13,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38619.85,
+        "name": "lh:audit:font-size",
+        "duration": 1.37,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38621.75,
+        "name": "lh:audit:link-text",
+        "duration": 5.72,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38628.01,
+        "name": "lh:audit:is-crawlable",
+        "duration": 0.98,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38629.95,
+        "name": "lh:audit:robots-txt",
+        "duration": 1.28,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38632.18,
+        "name": "lh:audit:tap-targets",
+        "duration": 0.77,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38633.18,
+        "name": "lh:audit:hreflang",
+        "duration": 0.53,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38633.89,
+        "name": "lh:audit:plugins",
+        "duration": 0.69,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38634.81,
+        "name": "lh:audit:canonical",
+        "duration": 0.56,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38635.73,
+        "name": "lh:audit:structured-data",
+        "duration": 0.43,
+        "entryType": "measure"
+      },
+      {
+        "startTime": 38636.66,
+        "name": "lh:runner:generate",
+        "duration": 10.8,
+        "entryType": "measure"
+      }
+    ],
+    "total": 31547.62
+  },
+  "i18n": {
+    "rendererFormattedStrings": {
+      "auditGroupExpandTooltip": "Show audits",
+      "crcInitialNavigation": "Initial Navigation",
+      "crcLongestDurationLabel": "Maximum critical path latency:",
+      "errorLabel": "Error!",
+      "errorMissingAuditInfo": "Report error: no audit information",
+      "labDataTitle": "Lab Data",
+      "lsPerformanceCategoryDescription": "[Lighthouse](https://developers.google.com/web/tools/lighthouse/) analysis of the current page on an emulated mobile network. Values are estimated and may vary.",
+      "manualAuditsGroupTitle": "Additional items to manually check",
+      "notApplicableAuditsGroupTitle": "Not applicable",
+      "opportunityResourceColumnLabel": "Opportunity",
+      "opportunitySavingsColumnLabel": "Estimated Savings",
+      "passedAuditsGroupTitle": "Passed audits",
+      "snippetCollapseButtonLabel": "Collapse snippet",
+      "snippetExpandButtonLabel": "Expand snippet",
+      "thirdPartyResourcesLabel": "Show 3rd-party resources",
+      "toplevelWarningsMessage": "There were issues affecting this run of Lighthouse:",
+      "varianceDisclaimer": "Values are estimated and may vary. The performance score is [based only on these metrics](https://github.com/GoogleChrome/lighthouse/blob/d2ec9ffbb21de9ad1a0f86ed24575eda32c796f0/docs/scoring.md#how-are-the-scores-weighted).",
+      "warningAuditsGroupTitle": "Passed audits but with warnings",
+      "warningHeader": "Warnings: "
+    },
+    "icuMessagePaths": {
+      "lighthouse-core/lib/lh-error.js | pageLoadFailedWithDetails": [
+        {
+          "values": {
+            "errorCode": "FAILED_DOCUMENT_REQUEST",
+            "errorDetails": "net::ERR_CERT_AUTHORITY_INVALID"
+          },
+          "path": "runWarnings[0]"
+        },
+        {
+          "values": {
+            "errorCode": "FAILED_DOCUMENT_REQUEST",
+            "errorDetails": "net::ERR_CERT_AUTHORITY_INVALID"
+          },
+          "path": "runtimeError.message"
+        }
+      ],
+      "lighthouse-core/audits/is-on-https.js | title": [
+        "audits[is-on-https].title"
+      ],
+      "lighthouse-core/audits/is-on-https.js | description": [
+        "audits[is-on-https].description"
+      ],
+      "lighthouse-core/lib/lh-error.js | missingRequiredArtifact": [
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[is-on-https].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "HTTPRedirect"
+          },
+          "path": "audits[redirects-http].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ServiceWorker"
+          },
+          "path": "audits[service-worker].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Offline"
+          },
+          "path": "audits[works-offline].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "MetaElements"
+          },
+          "path": "audits.viewport.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "HTMLWithoutJavaScript"
+          },
+          "path": "audits[without-javascript].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[first-contentful-paint].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[first-meaningful-paint].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[load-fast-enough-for-pwa].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[speed-index].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[screenshot-thumbnails].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[final-screenshot].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[estimated-input-latency].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[total-blocking-time].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[max-potential-fid].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ConsoleMessages"
+          },
+          "path": "audits[errors-in-console].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[time-to-first-byte].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[first-cpu-idle].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits.interactive.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[user-timings].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[critical-request-chains].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits.redirects.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "LinkElements"
+          },
+          "path": "audits[apple-touch-icon].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "MetaElements"
+          },
+          "path": "audits[themed-omnibox].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ViewportDimensions"
+          },
+          "path": "audits[content-width].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ImageElements"
+          },
+          "path": "audits[image-aspect-ratio].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ConsoleMessages"
+          },
+          "path": "audits.deprecations.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[mainthread-work-breakdown].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[bootup-time].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[uses-rel-preload].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[uses-rel-preconnect].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[font-display].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits.diagnostics.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[network-requests].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[network-rtt].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[network-server-latency].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[main-thread-tasks].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits.metrics.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "StartUrl"
+          },
+          "path": "audits[offline-start-url].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[performance-budget].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[resource-summary].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "traces"
+          },
+          "path": "audits[third-party-summary].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits.accesskeys.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[aria-allowed-attr].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[aria-required-attr].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[aria-required-children].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[aria-required-parent].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[aria-roles].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[aria-valid-attr-value].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[aria-valid-attr].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[audio-caption].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[button-name].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits.bypass.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[color-contrast].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[definition-list].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits.dlitem.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[document-title].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[duplicate-id].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[frame-title].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[html-has-lang].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[html-lang-valid].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[image-alt].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[input-image-alt].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits.label.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[layout-table].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[link-name].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits.list.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits.listitem.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[meta-refresh].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[meta-viewport].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[object-alt].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits.tabindex.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[td-headers-attr].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[th-has-data-cells].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[valid-lang].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[video-caption].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Accessibility"
+          },
+          "path": "audits[video-description].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[uses-long-cache-ttl].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[total-byte-weight].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ImageElements"
+          },
+          "path": "audits[offscreen-images].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "TagsBlockingFirstPaint"
+          },
+          "path": "audits[render-blocking-resources].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "CSSUsage"
+          },
+          "path": "audits[unminified-css].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ScriptElements"
+          },
+          "path": "audits[unminified-javascript].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "CSSUsage"
+          },
+          "path": "audits[unused-css-rules].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "OptimizedImages"
+          },
+          "path": "audits[uses-webp-images].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "OptimizedImages"
+          },
+          "path": "audits[uses-optimized-images].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ResponseCompression"
+          },
+          "path": "audits[uses-text-compression].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ImageElements"
+          },
+          "path": "audits[uses-responsive-images].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[efficient-animated-content].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "AppCacheManifest"
+          },
+          "path": "audits[appcache-manifest].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "Doctype"
+          },
+          "path": "audits.doctype.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "DOMStats"
+          },
+          "path": "audits[dom-size].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "AnchorElements"
+          },
+          "path": "audits[external-anchors-use-rel-noopener].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ConsoleMessages"
+          },
+          "path": "audits[geolocation-on-start].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ConsoleMessages"
+          },
+          "path": "audits[no-document-write].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ConsoleMessages"
+          },
+          "path": "audits[notification-on-start].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "PasswordInputsWithPreventedPaste"
+          },
+          "path": "audits[password-inputs-can-be-pasted-into].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[uses-http2].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "ConsoleMessages"
+          },
+          "path": "audits[uses-passive-event-listeners].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "MetaElements"
+          },
+          "path": "audits[meta-description].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "devtoolsLogs"
+          },
+          "path": "audits[http-status-code].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "FontSize"
+          },
+          "path": "audits[font-size].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "AnchorElements"
+          },
+          "path": "audits[link-text].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "MetaElements"
+          },
+          "path": "audits[is-crawlable].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "RobotsTxt"
+          },
+          "path": "audits[robots-txt].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "MetaElements"
+          },
+          "path": "audits[tap-targets].errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "LinkElements"
+          },
+          "path": "audits.hreflang.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "EmbeddedContent"
+          },
+          "path": "audits.plugins.errorMessage"
+        },
+        {
+          "values": {
+            "errorCode": "MISSING_REQUIRED_ARTIFACT",
+            "artifactName": "LinkElements"
+          },
+          "path": "audits.canonical.errorMessage"
+        }
+      ],
+      "lighthouse-core/audits/redirects-http.js | title": [
+        "audits[redirects-http].title"
+      ],
+      "lighthouse-core/audits/redirects-http.js | description": [
+        "audits[redirects-http].description"
+      ],
+      "lighthouse-core/audits/service-worker.js | title": [
+        "audits[service-worker].title"
+      ],
+      "lighthouse-core/audits/service-worker.js | description": [
+        "audits[service-worker].description"
+      ],
+      "lighthouse-core/audits/works-offline.js | title": [
+        "audits[works-offline].title"
+      ],
+      "lighthouse-core/audits/works-offline.js | description": [
+        "audits[works-offline].description"
+      ],
+      "lighthouse-core/audits/viewport.js | title": [
+        "audits.viewport.title"
+      ],
+      "lighthouse-core/audits/viewport.js | description": [
+        "audits.viewport.description"
+      ],
+      "lighthouse-core/audits/without-javascript.js | title": [
+        "audits[without-javascript].title"
+      ],
+      "lighthouse-core/audits/without-javascript.js | description": [
+        "audits[without-javascript].description"
+      ],
+      "lighthouse-core/audits/metrics/first-contentful-paint.js | title": [
+        "audits[first-contentful-paint].title"
+      ],
+      "lighthouse-core/audits/metrics/first-contentful-paint.js | description": [
+        "audits[first-contentful-paint].description"
+      ],
+      "lighthouse-core/audits/metrics/first-meaningful-paint.js | title": [
+        "audits[first-meaningful-paint].title"
+      ],
+      "lighthouse-core/audits/metrics/first-meaningful-paint.js | description": [
+        "audits[first-meaningful-paint].description"
+      ],
+      "lighthouse-core/audits/load-fast-enough-for-pwa.js | title": [
+        "audits[load-fast-enough-for-pwa].title"
+      ],
+      "lighthouse-core/audits/load-fast-enough-for-pwa.js | description": [
+        "audits[load-fast-enough-for-pwa].description"
+      ],
+      "lighthouse-core/audits/metrics/speed-index.js | title": [
+        "audits[speed-index].title"
+      ],
+      "lighthouse-core/audits/metrics/speed-index.js | description": [
+        "audits[speed-index].description"
+      ],
+      "lighthouse-core/audits/metrics/estimated-input-latency.js | title": [
+        "audits[estimated-input-latency].title"
+      ],
+      "lighthouse-core/audits/metrics/estimated-input-latency.js | description": [
+        "audits[estimated-input-latency].description"
+      ],
+      "lighthouse-core/audits/metrics/total-blocking-time.js | title": [
+        "audits[total-blocking-time].title"
+      ],
+      "lighthouse-core/audits/metrics/total-blocking-time.js | description": [
+        "audits[total-blocking-time].description"
+      ],
+      "lighthouse-core/audits/metrics/max-potential-fid.js | title": [
+        "audits[max-potential-fid].title"
+      ],
+      "lighthouse-core/audits/metrics/max-potential-fid.js | description": [
+        "audits[max-potential-fid].description"
+      ],
+      "lighthouse-core/audits/errors-in-console.js | title": [
+        "audits[errors-in-console].title"
+      ],
+      "lighthouse-core/audits/errors-in-console.js | description": [
+        "audits[errors-in-console].description"
+      ],
+      "lighthouse-core/audits/time-to-first-byte.js | title": [
+        "audits[time-to-first-byte].title"
+      ],
+      "lighthouse-core/audits/time-to-first-byte.js | description": [
+        "audits[time-to-first-byte].description"
+      ],
+      "lighthouse-core/audits/metrics/first-cpu-idle.js | title": [
+        "audits[first-cpu-idle].title"
+      ],
+      "lighthouse-core/audits/metrics/first-cpu-idle.js | description": [
+        "audits[first-cpu-idle].description"
+      ],
+      "lighthouse-core/audits/metrics/interactive.js | title": [
+        "audits.interactive.title"
+      ],
+      "lighthouse-core/audits/metrics/interactive.js | description": [
+        "audits.interactive.description"
+      ],
+      "lighthouse-core/audits/user-timings.js | title": [
+        "audits[user-timings].title"
+      ],
+      "lighthouse-core/audits/user-timings.js | description": [
+        "audits[user-timings].description"
+      ],
+      "lighthouse-core/audits/critical-request-chains.js | title": [
+        "audits[critical-request-chains].title"
+      ],
+      "lighthouse-core/audits/critical-request-chains.js | description": [
+        "audits[critical-request-chains].description"
+      ],
+      "lighthouse-core/audits/redirects.js | title": [
+        "audits.redirects.title"
+      ],
+      "lighthouse-core/audits/redirects.js | description": [
+        "audits.redirects.description"
+      ],
+      "lighthouse-core/audits/installable-manifest.js | failureTitle": [
+        "audits[installable-manifest].title"
+      ],
+      "lighthouse-core/audits/installable-manifest.js | description": [
+        "audits[installable-manifest].description"
+      ],
+      "lighthouse-core/audits/apple-touch-icon.js | title": [
+        "audits[apple-touch-icon].title"
+      ],
+      "lighthouse-core/audits/apple-touch-icon.js | description": [
+        "audits[apple-touch-icon].description"
+      ],
+      "lighthouse-core/audits/splash-screen.js | failureTitle": [
+        "audits[splash-screen].title"
+      ],
+      "lighthouse-core/audits/splash-screen.js | description": [
+        "audits[splash-screen].description"
+      ],
+      "lighthouse-core/audits/themed-omnibox.js | title": [
+        "audits[themed-omnibox].title"
+      ],
+      "lighthouse-core/audits/themed-omnibox.js | description": [
+        "audits[themed-omnibox].description"
+      ],
+      "lighthouse-core/audits/content-width.js | title": [
+        "audits[content-width].title"
+      ],
+      "lighthouse-core/audits/content-width.js | description": [
+        "audits[content-width].description"
+      ],
+      "lighthouse-core/audits/image-aspect-ratio.js | title": [
+        "audits[image-aspect-ratio].title"
+      ],
+      "lighthouse-core/audits/image-aspect-ratio.js | description": [
+        "audits[image-aspect-ratio].description"
+      ],
+      "lighthouse-core/audits/deprecations.js | title": [
+        "audits.deprecations.title"
+      ],
+      "lighthouse-core/audits/deprecations.js | description": [
+        "audits.deprecations.description"
+      ],
+      "lighthouse-core/audits/mainthread-work-breakdown.js | title": [
+        "audits[mainthread-work-breakdown].title"
+      ],
+      "lighthouse-core/audits/mainthread-work-breakdown.js | description": [
+        "audits[mainthread-work-breakdown].description"
+      ],
+      "lighthouse-core/audits/bootup-time.js | title": [
+        "audits[bootup-time].title"
+      ],
+      "lighthouse-core/audits/bootup-time.js | description": [
+        "audits[bootup-time].description"
+      ],
+      "lighthouse-core/audits/uses-rel-preload.js | title": [
+        "audits[uses-rel-preload].title"
+      ],
+      "lighthouse-core/audits/uses-rel-preload.js | description": [
+        "audits[uses-rel-preload].description"
+      ],
+      "lighthouse-core/audits/uses-rel-preconnect.js | title": [
+        "audits[uses-rel-preconnect].title"
+      ],
+      "lighthouse-core/audits/uses-rel-preconnect.js | description": [
+        "audits[uses-rel-preconnect].description"
+      ],
+      "lighthouse-core/audits/font-display.js | title": [
+        "audits[font-display].title"
+      ],
+      "lighthouse-core/audits/font-display.js | description": [
+        "audits[font-display].description"
+      ],
+      "lighthouse-core/audits/network-rtt.js | title": [
+        "audits[network-rtt].title"
+      ],
+      "lighthouse-core/audits/network-rtt.js | description": [
+        "audits[network-rtt].description"
+      ],
+      "lighthouse-core/audits/network-server-latency.js | title": [
+        "audits[network-server-latency].title"
+      ],
+      "lighthouse-core/audits/network-server-latency.js | description": [
+        "audits[network-server-latency].description"
+      ],
+      "lighthouse-core/audits/offline-start-url.js | title": [
+        "audits[offline-start-url].title"
+      ],
+      "lighthouse-core/audits/offline-start-url.js | description": [
+        "audits[offline-start-url].description"
+      ],
+      "lighthouse-core/audits/performance-budget.js | title": [
+        "audits[performance-budget].title"
+      ],
+      "lighthouse-core/audits/performance-budget.js | description": [
+        "audits[performance-budget].description"
+      ],
+      "lighthouse-core/audits/resource-summary.js | title": [
+        "audits[resource-summary].title"
+      ],
+      "lighthouse-core/audits/resource-summary.js | description": [
+        "audits[resource-summary].description"
+      ],
+      "lighthouse-core/audits/third-party-summary.js | title": [
+        "audits[third-party-summary].title"
+      ],
+      "lighthouse-core/audits/third-party-summary.js | description": [
+        "audits[third-party-summary].description"
+      ],
+      "lighthouse-core/audits/manual/pwa-cross-browser.js | title": [
+        "audits[pwa-cross-browser].title"
+      ],
+      "lighthouse-core/audits/manual/pwa-cross-browser.js | description": [
+        "audits[pwa-cross-browser].description"
+      ],
+      "lighthouse-core/audits/manual/pwa-page-transitions.js | title": [
+        "audits[pwa-page-transitions].title"
+      ],
+      "lighthouse-core/audits/manual/pwa-page-transitions.js | description": [
+        "audits[pwa-page-transitions].description"
+      ],
+      "lighthouse-core/audits/manual/pwa-each-page-has-url.js | title": [
+        "audits[pwa-each-page-has-url].title"
+      ],
+      "lighthouse-core/audits/manual/pwa-each-page-has-url.js | description": [
+        "audits[pwa-each-page-has-url].description"
+      ],
+      "lighthouse-core/audits/accessibility/accesskeys.js | title": [
+        "audits.accesskeys.title"
+      ],
+      "lighthouse-core/audits/accessibility/accesskeys.js | description": [
+        "audits.accesskeys.description"
+      ],
+      "lighthouse-core/audits/accessibility/aria-allowed-attr.js | title": [
+        "audits[aria-allowed-attr].title"
+      ],
+      "lighthouse-core/audits/accessibility/aria-allowed-attr.js | description": [
+        "audits[aria-allowed-attr].description"
+      ],
+      "lighthouse-core/audits/accessibility/aria-required-attr.js | title": [
+        "audits[aria-required-attr].title"
+      ],
+      "lighthouse-core/audits/accessibility/aria-required-attr.js | description": [
+        "audits[aria-required-attr].description"
+      ],
+      "lighthouse-core/audits/accessibility/aria-required-children.js | title": [
+        "audits[aria-required-children].title"
+      ],
+      "lighthouse-core/audits/accessibility/aria-required-children.js | description": [
+        "audits[aria-required-children].description"
+      ],
+      "lighthouse-core/audits/accessibility/aria-required-parent.js | title": [
+        "audits[aria-required-parent].title"
+      ],
+      "lighthouse-core/audits/accessibility/aria-required-parent.js | description": [
+        "audits[aria-required-parent].description"
+      ],
+      "lighthouse-core/audits/accessibility/aria-roles.js | title": [
+        "audits[aria-roles].title"
+      ],
+      "lighthouse-core/audits/accessibility/aria-roles.js | description": [
+        "audits[aria-roles].description"
+      ],
+      "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | title": [
+        "audits[aria-valid-attr-value].title"
+      ],
+      "lighthouse-core/audits/accessibility/aria-valid-attr-value.js | description": [
+        "audits[aria-valid-attr-value].description"
+      ],
+      "lighthouse-core/audits/accessibility/aria-valid-attr.js | title": [
+        "audits[aria-valid-attr].title"
+      ],
+      "lighthouse-core/audits/accessibility/aria-valid-attr.js | description": [
+        "audits[aria-valid-attr].description"
+      ],
+      "lighthouse-core/audits/accessibility/audio-caption.js | title": [
+        "audits[audio-caption].title"
+      ],
+      "lighthouse-core/audits/accessibility/audio-caption.js | description": [
+        "audits[audio-caption].description"
+      ],
+      "lighthouse-core/audits/accessibility/button-name.js | title": [
+        "audits[button-name].title"
+      ],
+      "lighthouse-core/audits/accessibility/button-name.js | description": [
+        "audits[button-name].description"
+      ],
+      "lighthouse-core/audits/accessibility/bypass.js | title": [
+        "audits.bypass.title"
+      ],
+      "lighthouse-core/audits/accessibility/bypass.js | description": [
+        "audits.bypass.description"
+      ],
+      "lighthouse-core/audits/accessibility/color-contrast.js | title": [
+        "audits[color-contrast].title"
+      ],
+      "lighthouse-core/audits/accessibility/color-contrast.js | description": [
+        "audits[color-contrast].description"
+      ],
+      "lighthouse-core/audits/accessibility/definition-list.js | title": [
+        "audits[definition-list].title"
+      ],
+      "lighthouse-core/audits/accessibility/definition-list.js | description": [
+        "audits[definition-list].description"
+      ],
+      "lighthouse-core/audits/accessibility/dlitem.js | title": [
+        "audits.dlitem.title"
+      ],
+      "lighthouse-core/audits/accessibility/dlitem.js | description": [
+        "audits.dlitem.description"
+      ],
+      "lighthouse-core/audits/accessibility/document-title.js | title": [
+        "audits[document-title].title"
+      ],
+      "lighthouse-core/audits/accessibility/document-title.js | description": [
+        "audits[document-title].description"
+      ],
+      "lighthouse-core/audits/accessibility/duplicate-id.js | title": [
+        "audits[duplicate-id].title"
+      ],
+      "lighthouse-core/audits/accessibility/duplicate-id.js | description": [
+        "audits[duplicate-id].description"
+      ],
+      "lighthouse-core/audits/accessibility/frame-title.js | title": [
+        "audits[frame-title].title"
+      ],
+      "lighthouse-core/audits/accessibility/frame-title.js | description": [
+        "audits[frame-title].description"
+      ],
+      "lighthouse-core/audits/accessibility/html-has-lang.js | title": [
+        "audits[html-has-lang].title"
+      ],
+      "lighthouse-core/audits/accessibility/html-has-lang.js | description": [
+        "audits[html-has-lang].description"
+      ],
+      "lighthouse-core/audits/accessibility/html-lang-valid.js | title": [
+        "audits[html-lang-valid].title"
+      ],
+      "lighthouse-core/audits/accessibility/html-lang-valid.js | description": [
+        "audits[html-lang-valid].description"
+      ],
+      "lighthouse-core/audits/accessibility/image-alt.js | title": [
+        "audits[image-alt].title"
+      ],
+      "lighthouse-core/audits/accessibility/image-alt.js | description": [
+        "audits[image-alt].description"
+      ],
+      "lighthouse-core/audits/accessibility/input-image-alt.js | title": [
+        "audits[input-image-alt].title"
+      ],
+      "lighthouse-core/audits/accessibility/input-image-alt.js | description": [
+        "audits[input-image-alt].description"
+      ],
+      "lighthouse-core/audits/accessibility/label.js | title": [
+        "audits.label.title"
+      ],
+      "lighthouse-core/audits/accessibility/label.js | description": [
+        "audits.label.description"
+      ],
+      "lighthouse-core/audits/accessibility/layout-table.js | title": [
+        "audits[layout-table].title"
+      ],
+      "lighthouse-core/audits/accessibility/layout-table.js | description": [
+        "audits[layout-table].description"
+      ],
+      "lighthouse-core/audits/accessibility/link-name.js | title": [
+        "audits[link-name].title"
+      ],
+      "lighthouse-core/audits/accessibility/link-name.js | description": [
+        "audits[link-name].description"
+      ],
+      "lighthouse-core/audits/accessibility/list.js | title": [
+        "audits.list.title"
+      ],
+      "lighthouse-core/audits/accessibility/list.js | description": [
+        "audits.list.description"
+      ],
+      "lighthouse-core/audits/accessibility/listitem.js | title": [
+        "audits.listitem.title"
+      ],
+      "lighthouse-core/audits/accessibility/listitem.js | description": [
+        "audits.listitem.description"
+      ],
+      "lighthouse-core/audits/accessibility/meta-refresh.js | title": [
+        "audits[meta-refresh].title"
+      ],
+      "lighthouse-core/audits/accessibility/meta-refresh.js | description": [
+        "audits[meta-refresh].description"
+      ],
+      "lighthouse-core/audits/accessibility/meta-viewport.js | title": [
+        "audits[meta-viewport].title"
+      ],
+      "lighthouse-core/audits/accessibility/meta-viewport.js | description": [
+        "audits[meta-viewport].description"
+      ],
+      "lighthouse-core/audits/accessibility/object-alt.js | title": [
+        "audits[object-alt].title"
+      ],
+      "lighthouse-core/audits/accessibility/object-alt.js | description": [
+        "audits[object-alt].description"
+      ],
+      "lighthouse-core/audits/accessibility/tabindex.js | title": [
+        "audits.tabindex.title"
+      ],
+      "lighthouse-core/audits/accessibility/tabindex.js | description": [
+        "audits.tabindex.description"
+      ],
+      "lighthouse-core/audits/accessibility/td-headers-attr.js | title": [
+        "audits[td-headers-attr].title"
+      ],
+      "lighthouse-core/audits/accessibility/td-headers-attr.js | description": [
+        "audits[td-headers-attr].description"
+      ],
+      "lighthouse-core/audits/accessibility/th-has-data-cells.js | title": [
+        "audits[th-has-data-cells].title"
+      ],
+      "lighthouse-core/audits/accessibility/th-has-data-cells.js | description": [
+        "audits[th-has-data-cells].description"
+      ],
+      "lighthouse-core/audits/accessibility/valid-lang.js | title": [
+        "audits[valid-lang].title"
+      ],
+      "lighthouse-core/audits/accessibility/valid-lang.js | description": [
+        "audits[valid-lang].description"
+      ],
+      "lighthouse-core/audits/accessibility/video-caption.js | title": [
+        "audits[video-caption].title"
+      ],
+      "lighthouse-core/audits/accessibility/video-caption.js | description": [
+        "audits[video-caption].description"
+      ],
+      "lighthouse-core/audits/accessibility/video-description.js | title": [
+        "audits[video-description].title"
+      ],
+      "lighthouse-core/audits/accessibility/video-description.js | description": [
+        "audits[video-description].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | title": [
+        "audits[uses-long-cache-ttl].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/uses-long-cache-ttl.js | description": [
+        "audits[uses-long-cache-ttl].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | title": [
+        "audits[total-byte-weight].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/total-byte-weight.js | description": [
+        "audits[total-byte-weight].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/offscreen-images.js | title": [
+        "audits[offscreen-images].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/offscreen-images.js | description": [
+        "audits[offscreen-images].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | title": [
+        "audits[render-blocking-resources].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/render-blocking-resources.js | description": [
+        "audits[render-blocking-resources].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/unminified-css.js | title": [
+        "audits[unminified-css].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/unminified-css.js | description": [
+        "audits[unminified-css].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | title": [
+        "audits[unminified-javascript].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/unminified-javascript.js | description": [
+        "audits[unminified-javascript].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | title": [
+        "audits[unused-css-rules].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/unused-css-rules.js | description": [
+        "audits[unused-css-rules].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | title": [
+        "audits[uses-webp-images].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/uses-webp-images.js | description": [
+        "audits[uses-webp-images].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | title": [
+        "audits[uses-optimized-images].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/uses-optimized-images.js | description": [
+        "audits[uses-optimized-images].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | title": [
+        "audits[uses-text-compression].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/uses-text-compression.js | description": [
+        "audits[uses-text-compression].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | title": [
+        "audits[uses-responsive-images].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/uses-responsive-images.js | description": [
+        "audits[uses-responsive-images].description"
+      ],
+      "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | title": [
+        "audits[efficient-animated-content].title"
+      ],
+      "lighthouse-core/audits/byte-efficiency/efficient-animated-content.js | description": [
+        "audits[efficient-animated-content].description"
+      ],
+      "lighthouse-core/audits/dobetterweb/appcache-manifest.js | title": [
+        "audits[appcache-manifest].title"
+      ],
+      "lighthouse-core/audits/dobetterweb/appcache-manifest.js | description": [
+        "audits[appcache-manifest].description"
+      ],
+      "lighthouse-core/audits/dobetterweb/doctype.js | title": [
+        "audits.doctype.title"
+      ],
+      "lighthouse-core/audits/dobetterweb/doctype.js | description": [
+        "audits.doctype.description"
+      ],
+      "lighthouse-core/audits/dobetterweb/dom-size.js | title": [
+        "audits[dom-size].title"
+      ],
+      "lighthouse-core/audits/dobetterweb/dom-size.js | description": [
+        "audits[dom-size].description"
+      ],
+      "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | title": [
+        "audits[external-anchors-use-rel-noopener].title"
+      ],
+      "lighthouse-core/audits/dobetterweb/external-anchors-use-rel-noopener.js | description": [
+        "audits[external-anchors-use-rel-noopener].description"
+      ],
+      "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | title": [
+        "audits[geolocation-on-start].title"
+      ],
+      "lighthouse-core/audits/dobetterweb/geolocation-on-start.js | description": [
+        "audits[geolocation-on-start].description"
+      ],
+      "lighthouse-core/audits/dobetterweb/no-document-write.js | title": [
+        "audits[no-document-write].title"
+      ],
+      "lighthouse-core/audits/dobetterweb/no-document-write.js | description": [
+        "audits[no-document-write].description"
+      ],
+      "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | title": [
+        "audits[no-vulnerable-libraries].title"
+      ],
+      "lighthouse-core/audits/dobetterweb/no-vulnerable-libraries.js | description": [
+        "audits[no-vulnerable-libraries].description"
+      ],
+      "lighthouse-core/audits/dobetterweb/js-libraries.js | title": [
+        "audits[js-libraries].title"
+      ],
+      "lighthouse-core/audits/dobetterweb/js-libraries.js | description": [
+        "audits[js-libraries].description"
+      ],
+      "lighthouse-core/audits/dobetterweb/notification-on-start.js | title": [
+        "audits[notification-on-start].title"
+      ],
+      "lighthouse-core/audits/dobetterweb/notification-on-start.js | description": [
+        "audits[notification-on-start].description"
+      ],
+      "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | title": [
+        "audits[password-inputs-can-be-pasted-into].title"
+      ],
+      "lighthouse-core/audits/dobetterweb/password-inputs-can-be-pasted-into.js | description": [
+        "audits[password-inputs-can-be-pasted-into].description"
+      ],
+      "lighthouse-core/audits/dobetterweb/uses-http2.js | title": [
+        "audits[uses-http2].title"
+      ],
+      "lighthouse-core/audits/dobetterweb/uses-http2.js | description": [
+        "audits[uses-http2].description"
+      ],
+      "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | title": [
+        "audits[uses-passive-event-listeners].title"
+      ],
+      "lighthouse-core/audits/dobetterweb/uses-passive-event-listeners.js | description": [
+        "audits[uses-passive-event-listeners].description"
+      ],
+      "lighthouse-core/audits/seo/meta-description.js | title": [
+        "audits[meta-description].title"
+      ],
+      "lighthouse-core/audits/seo/meta-description.js | description": [
+        "audits[meta-description].description"
+      ],
+      "lighthouse-core/audits/seo/http-status-code.js | title": [
+        "audits[http-status-code].title"
+      ],
+      "lighthouse-core/audits/seo/http-status-code.js | description": [
+        "audits[http-status-code].description"
+      ],
+      "lighthouse-core/audits/seo/font-size.js | title": [
+        "audits[font-size].title"
+      ],
+      "lighthouse-core/audits/seo/font-size.js | description": [
+        "audits[font-size].description"
+      ],
+      "lighthouse-core/audits/seo/link-text.js | title": [
+        "audits[link-text].title"
+      ],
+      "lighthouse-core/audits/seo/link-text.js | description": [
+        "audits[link-text].description"
+      ],
+      "lighthouse-core/audits/seo/is-crawlable.js | title": [
+        "audits[is-crawlable].title"
+      ],
+      "lighthouse-core/audits/seo/is-crawlable.js | description": [
+        "audits[is-crawlable].description"
+      ],
+      "lighthouse-core/audits/seo/robots-txt.js | title": [
+        "audits[robots-txt].title"
+      ],
+      "lighthouse-core/audits/seo/robots-txt.js | description": [
+        "audits[robots-txt].description"
+      ],
+      "lighthouse-core/audits/seo/tap-targets.js | title": [
+        "audits[tap-targets].title"
+      ],
+      "lighthouse-core/audits/seo/tap-targets.js | description": [
+        "audits[tap-targets].description"
+      ],
+      "lighthouse-core/audits/seo/hreflang.js | title": [
+        "audits.hreflang.title"
+      ],
+      "lighthouse-core/audits/seo/hreflang.js | description": [
+        "audits.hreflang.description"
+      ],
+      "lighthouse-core/audits/seo/plugins.js | title": [
+        "audits.plugins.title"
+      ],
+      "lighthouse-core/audits/seo/plugins.js | description": [
+        "audits.plugins.description"
+      ],
+      "lighthouse-core/audits/seo/canonical.js | title": [
+        "audits.canonical.title"
+      ],
+      "lighthouse-core/audits/seo/canonical.js | description": [
+        "audits.canonical.description"
+      ],
+      "lighthouse-core/audits/seo/manual/structured-data.js | title": [
+        "audits[structured-data].title"
+      ],
+      "lighthouse-core/audits/seo/manual/structured-data.js | description": [
+        "audits[structured-data].description"
+      ],
+      "lighthouse-core/config/default-config.js | performanceCategoryTitle": [
+        "categories.performance.title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yCategoryTitle": [
+        "categories.accessibility.title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yCategoryDescription": [
+        "categories.accessibility.description"
+      ],
+      "lighthouse-core/config/default-config.js | a11yCategoryManualDescription": [
+        "categories.accessibility.manualDescription"
+      ],
+      "lighthouse-core/config/default-config.js | bestPracticesCategoryTitle": [
+        "categories[best-practices].title"
+      ],
+      "lighthouse-core/config/default-config.js | seoCategoryTitle": [
+        "categories.seo.title"
+      ],
+      "lighthouse-core/config/default-config.js | seoCategoryDescription": [
+        "categories.seo.description"
+      ],
+      "lighthouse-core/config/default-config.js | seoCategoryManualDescription": [
+        "categories.seo.manualDescription"
+      ],
+      "lighthouse-core/config/default-config.js | pwaCategoryTitle": [
+        "categories.pwa.title"
+      ],
+      "lighthouse-core/config/default-config.js | pwaCategoryDescription": [
+        "categories.pwa.description"
+      ],
+      "lighthouse-core/config/default-config.js | pwaCategoryManualDescription": [
+        "categories.pwa.manualDescription"
+      ],
+      "lighthouse-core/config/default-config.js | metricGroupTitle": [
+        "categoryGroups.metrics.title"
+      ],
+      "lighthouse-core/config/default-config.js | loadOpportunitiesGroupTitle": [
+        "categoryGroups[load-opportunities].title"
+      ],
+      "lighthouse-core/config/default-config.js | loadOpportunitiesGroupDescription": [
+        "categoryGroups[load-opportunities].description"
+      ],
+      "lighthouse-core/config/default-config.js | budgetsGroupTitle": [
+        "categoryGroups.budgets.title"
+      ],
+      "lighthouse-core/config/default-config.js | budgetsGroupDescription": [
+        "categoryGroups.budgets.description"
+      ],
+      "lighthouse-core/config/default-config.js | diagnosticsGroupTitle": [
+        "categoryGroups.diagnostics.title"
+      ],
+      "lighthouse-core/config/default-config.js | diagnosticsGroupDescription": [
+        "categoryGroups.diagnostics.description"
+      ],
+      "lighthouse-core/config/default-config.js | pwaFastReliableGroupTitle": [
+        "categoryGroups[pwa-fast-reliable].title"
+      ],
+      "lighthouse-core/config/default-config.js | pwaInstallableGroupTitle": [
+        "categoryGroups[pwa-installable].title"
+      ],
+      "lighthouse-core/config/default-config.js | pwaOptimizedGroupTitle": [
+        "categoryGroups[pwa-optimized].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yBestPracticesGroupTitle": [
+        "categoryGroups[a11y-best-practices].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yBestPracticesGroupDescription": [
+        "categoryGroups[a11y-best-practices].description"
+      ],
+      "lighthouse-core/config/default-config.js | a11yColorContrastGroupTitle": [
+        "categoryGroups[a11y-color-contrast].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yColorContrastGroupDescription": [
+        "categoryGroups[a11y-color-contrast].description"
+      ],
+      "lighthouse-core/config/default-config.js | a11yNamesLabelsGroupTitle": [
+        "categoryGroups[a11y-names-labels].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yNamesLabelsGroupDescription": [
+        "categoryGroups[a11y-names-labels].description"
+      ],
+      "lighthouse-core/config/default-config.js | a11yNavigationGroupTitle": [
+        "categoryGroups[a11y-navigation].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yNavigationGroupDescription": [
+        "categoryGroups[a11y-navigation].description"
+      ],
+      "lighthouse-core/config/default-config.js | a11yAriaGroupTitle": [
+        "categoryGroups[a11y-aria].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yAriaGroupDescription": [
+        "categoryGroups[a11y-aria].description"
+      ],
+      "lighthouse-core/config/default-config.js | a11yLanguageGroupTitle": [
+        "categoryGroups[a11y-language].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yLanguageGroupDescription": [
+        "categoryGroups[a11y-language].description"
+      ],
+      "lighthouse-core/config/default-config.js | a11yAudioVideoGroupTitle": [
+        "categoryGroups[a11y-audio-video].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yAudioVideoGroupDescription": [
+        "categoryGroups[a11y-audio-video].description"
+      ],
+      "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupTitle": [
+        "categoryGroups[a11y-tables-lists].title"
+      ],
+      "lighthouse-core/config/default-config.js | a11yTablesListsVideoGroupDescription": [
+        "categoryGroups[a11y-tables-lists].description"
+      ],
+      "lighthouse-core/config/default-config.js | seoMobileGroupTitle": [
+        "categoryGroups[seo-mobile].title"
+      ],
+      "lighthouse-core/config/default-config.js | seoMobileGroupDescription": [
+        "categoryGroups[seo-mobile].description"
+      ],
+      "lighthouse-core/config/default-config.js | seoContentGroupTitle": [
+        "categoryGroups[seo-content].title"
+      ],
+      "lighthouse-core/config/default-config.js | seoContentGroupDescription": [
+        "categoryGroups[seo-content].description"
+      ],
+      "lighthouse-core/config/default-config.js | seoCrawlingGroupTitle": [
+        "categoryGroups[seo-crawl].title"
+      ],
+      "lighthouse-core/config/default-config.js | seoCrawlingGroupDescription": [
+        "categoryGroups[seo-crawl].description"
+      ]
+    }
+  },
+  "stackPacks": []
+}

--- a/test.js
+++ b/test.js
@@ -5,24 +5,21 @@ const createLighthouse = require('.')
 exports.handler = function (event, context, callback) {
   Promise.resolve()
     .then(() => createLighthouse(event.url || 'https://example.com', { logLevel: 'info' }))
-    .then(({ chrome, start }) => {
-      return start()
-        .then((results) => {
-          if (event.saveResults) {
-            const filename = results.lhr.lighthouseVersion.split('-')[0]
-            fs.writeFileSync(path.join(__dirname, `results/${filename}.json`), `${JSON.stringify(results.lhr, null, 2)}\n`)
-            fs.writeFileSync(path.join(__dirname, `results/${filename}.html`), results.report)
-          }
-          return chrome.kill().then(() => callback(null, {
-            url: results.lhr.requestedUrl,
-            timing: results.lhr.timing,
-            userAgent: results.lhr.userAgent,
-            lighthouseVersion: results.lhr.lighthouseVersion
-          }))
-        })
-        .catch((error) => {
-          return chrome.kill().then(() => callback(error))
-        })
+    .then(({ chrome, results }) => {
+      if (event.saveResults) {
+        const filename = results.lhr.lighthouseVersion.split('-')[0]
+        fs.writeFileSync(path.join(__dirname, `results/${filename}.json`), `${JSON.stringify(results.lhr, null, 2)}\n`)
+        fs.writeFileSync(path.join(__dirname, `results/${filename}.html`), results.report)
+      }
+      return chrome.kill().then(() => callback(null, {
+        url: results.lhr.requestedUrl,
+        timing: results.lhr.timing,
+        userAgent: results.lhr.userAgent,
+        lighthouseVersion: results.lhr.lighthouseVersion
+      }))
+    })
+    .catch((error) => {
+      return chrome.kill().then(() => callback(error))
     })
     .catch(callback)
 }


### PR DESCRIPTION
Since 8.10 is no longer available on AWS, this update brings the project up to Node10/12 as well lighthouse version 5.6.
Also updates vulnerable npm packages.
the main things that are happening is swapping serverless for chrome-aws-lambda and using await.
I have updated the test as well, but probably needs further testing.
Also still needs Readme updates.  If you intend to merge this I will write that as well.